### PR TITLE
drawing.C geometry improvement

### DIFF
--- a/drawing.C
+++ b/drawing.C
@@ -335,8 +335,8 @@ Drawing::Drawing (ToddCoxeter::Graph* g)
 
     //define original polygon
     for (int i = 0; i<POLY_SIDES; ++i) {
-        poly0[i][0] = cos((2.0f*M_PI*i)/POLY_SIDES);
-        poly0[i][1] = sin((2.0f*M_PI*i)/POLY_SIDES);
+        poly0[i][0] = -sin((2.0f*M_PI*i)/POLY_SIDES);
+        poly0[i][1] =  cos((2.0f*M_PI*i)/POLY_SIDES);
     }
 
     //define original sphere


### PR DESCRIPTION
Hallo

i try to use jenn to create a set of 3D models. i modified the code a little to generate low polygon models.
by proofing the result i detect some possible little improvements:
- it creates some edges twice
  (i don't fix this now, but i think to separate the vertex draw from the edge draw would be useful. and to use a hashset (std::set) for a double cleaned list to draw the edges.)
- (not sure about this) the edges which are using the center point {0,0,0} as starting point can degenerate. it cause a distortion of the rotation of the tube rings. only because of float math unprecision it is mostly not exactly {0,0,0}, so it seams to work. i speculate that the orientation of the tube rings is distorted if the starting points are exact {0,0,0}, because the math loses the information for the rotation of the edge. This can be tested whit polychora 5-Cell 322323, it has 4 edges passing the center, 3 of them start in the center. but i am not sure if i see this correct, i am not a mathematician.)
- the edges could be aligned to look away from the center in a geometric correct way. so if the edge tubes are of a triangle rotation shape, the edges would line up to each other correctly.
  the only thing i get done to fix partially:
  i could fix the edges surrounding the geometry but not 100%, and not this ones which point to the center.
  (i used a dirty hack to suppress the automatic polygon smoothing algo, and forced a 3 geometry shape for the tubes, to check the orientation of the edge tubes.)
- the vertex spheres could too point in the direction of the geometric tip-center (sphere poles pointing to the edge tip). not all spheres point to the object center, so the surrounding geometry determines the orientation of the vertex spheres (and the rotation of the connecting edges). vertex-sphere and edge-tubes could use the same alignment orientation. if 3 ore more vertexes are connected to the vertex where a sphere is placed, a cross-product/normal could align the sphere, otherwise the direction to the object center.
  if jenn would support this, it would be possible to reduce the polygon count and increase so the speed, specially for the very complex structures. if the symmetry of the geometry fits, less polygon resolution would still look nice and correct. (but this is maybe not a easy thing to fix)
- i try to get the faces in to the export file, as seperate sub-objects for vertexes, edges and faces. without success for now...

for now i was not able to fix what i detect. i will try to see if i am able to improve the geometry.
don't know it this is from any interest here, because the improvements are only visible in low polygon geometry and are perfectionistic and not bugs.
pleas don't see this as criticism, because the program is great.
