### PR TITLE
Improve mobile experience

### DIFF
--- a/drawing.h
+++ b/drawing.h
@@ -112,7 +112,7 @@ class Drawing
     float scale, q_scale;
     bool _grid_on;
     bool _drawing_verts, _drawing_edges, _drawing_faces;
-    bool _fancy, _hazy, _wireframe, _high_quality;
+    bool _fancy, _hazy, _wireframe, _curved, _high_quality;
     bool _clipping;
     bool _update_needed;
 public:
@@ -127,8 +127,8 @@ public:
     void toggle_fancy ();
     void toggle_hazy ();
     void toggle_wireframe ();
+    void toggle_curved ();
     void set_quality (bool quality);
-    void set_glut_params ();
     void set_scale (float scale);
     float get_tube_rad () { return tube_rad; }
     void set_tube_rad (float rad);

--- a/main.C
+++ b/main.C
@@ -222,6 +222,7 @@ void keyboard (unsigned char key, int w_x, int w_y)
         case 'e': drawing->toggle_edges();              break;
         case 'f': drawing->toggle_faces();              break;
         case 'l': drawing->toggle_fancy();              break;
+        case 'L': drawing->toggle_curved();             break;
         case 'H': drawing->toggle_hazy();               break;
         case 'w': projector->toggle_wireframe();        break;
         case 'K': projector->toggle_contrast();         break;

--- a/menus.C
+++ b/menus.C
@@ -580,6 +580,7 @@ const char * const style_message =
 edges\n\
 vertices\n\
 line-art\n\
+curved\n\
 wireframe\n\
 thinner\n\
 fatter\n\
@@ -607,10 +608,11 @@ void StyleMenu::_call (int N)
         case 1: drawing->toggle_edges();                             break;
         case 2: drawing->toggle_verts();                             break;
         case 3: drawing->toggle_fancy();                             break;
-        case 4: projector->toggle_wireframe();                       break;
-        case 5: drawing->set_tube_rad(drawing->get_tube_rad()/1.2f); break;
-        case 6: drawing->set_tube_rad(drawing->get_tube_rad()*1.2f); break;
-        case 7: drawing->toggle_hazy();                              break;
+        case 4: drawing->toggle_curved();                            break;
+        case 5: projector->toggle_wireframe();                       break;
+        case 6: drawing->set_tube_rad(drawing->get_tube_rad()/1.2f); break;
+        case 7: drawing->set_tube_rad(drawing->get_tube_rad()*1.2f); break;
+        case 8: drawing->toggle_hazy();                              break;
         default: delete this;
     }
 }

--- a/todd_coxeter.C
+++ b/todd_coxeter.C
@@ -152,7 +152,19 @@ public:
     }
     ~Vertex(void)
     {
-        if(next!= this) delete next;
+        // recursively calling the destructor may
+        // exceed the maximum call stack size
+        // if(next!= this) delete next;
+        Vertex *curr = this;
+        while (curr->next && curr->next != curr) {
+            curr = curr->next;
+        }
+
+        while (curr != this) {
+            curr = curr->prev;
+            delete curr->next;
+            curr->next = NULL;
+        }
     //logger.info() << "-" |0;
     }
 };

--- a/web/index.html
+++ b/web/index.html
@@ -899,13 +899,44 @@
     resizeTimer = setTimeout(resizeCanvas, 500);
   })
 
-  // only zoom when the mouse is on the canvas
-  const patchWheel = () => {
+  // zoom-related
+  let prevTouches;
+  const dist = (t) => (t[0].pageX - t[1].pageX) ** 2 + (t[0].pageY - t[1].pageY) ** 2;
+  const patchZoom = () => {
+    const canvas = Module.canvas;
+
+    // patch mouse wheel so that only scrolling on the canvas activates zoom
     window.removeEventListener("mousewheel", GLUT.onMouseWheel, true);
     window.removeEventListener("DOMMouseScroll", GLUT.onMouseWheel, true);
+    canvas.addEventListener("mousewheel", GLUT.onMouseWheel, true);
+    canvas.addEventListener("DOMMouseScroll", GLUT.onMouseWheel, true);
 
-    Module.canvas.addEventListener("mousewheel", GLUT.onMouseWheel, true);
-    Module.canvas.addEventListener("DOMMouseScroll", GLUT.onMouseWheel, true);
+    // prevent pinch to zoom on web content for iOS devices
+    document.addEventListener('gesturestart', (e) => e.preventDefault())
+
+    // pinch to zoom on touch devices
+    window.removeEventListener("touchmove", GLUT.touchHandler, true);
+    window.removeEventListener("touchstart", GLUT.touchHandler, true);
+    window.removeEventListener("touchend", GLUT.touchHandler, true);
+
+    const touchHandler = (event) => {
+      if (event.touches.length !== 2) {
+        GLUT.touchHandler(event);
+        return;
+      }
+
+      const currTouches = event.touches;
+      if (event.type !== "touchstart") {
+        const option = dist(prevTouches) > dist(currTouches) ? 1 : 2;
+        Module.select(2, option, -1)
+      }
+
+      prevTouches = currTouches;
+    }
+
+    canvas.addEventListener("touchmove", touchHandler, true);
+    canvas.addEventListener("touchstart", touchHandler, true);
+    canvas.addEventListener("touchend", touchHandler, true);
   }
 
   // control drag behavior
@@ -927,7 +958,7 @@
 
   // wasm module
   var Module = {
-    postRun: [() => resizeCanvas(), patchWheel],
+    postRun: [() => resizeCanvas(), patchZoom],
     arguments: "-c 3 2 2 4 2 3 -v 1 2 3 -s 300 150".split(" "),
     canvas: document.getElementById("canvas")
   };

--- a/web/index.html
+++ b/web/index.html
@@ -48,6 +48,16 @@
       touch-action: none;
       width: 100%;
     }
+
+    .dropdown-item {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .badge {
+      align-self: center;
+      margin-left: auto;
+    }
   </style>
 </head>
 
@@ -71,14 +81,14 @@
   </header>
 
   <div class="row">
-    <aside class="col-xl-2">
+    <aside class="col-xl-auto">
       <nav class="sidebar card py-2 mb-4">
         <ul class="nav flex-column">
           <li>
-            <a class="dropdown-item">Model<span class="float-end ms-2">»</span></a>
+            <a class="dropdown-item">Model<span class="ms-2">»</span></a>
             <ul class="submenu dropdown-menu">
               <li>
-                <a class="dropdown-item">polyhedra<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">polyhedra<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 0, 0)">tetrahedron</li>
                   <li class="dropdown-item" onclick="Module.select(1, 0, 1)">cube</li>
@@ -88,36 +98,36 @@
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">polychora<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">polychora<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 1, 0)">
                     5-cell
-                    <span class="float-end badge bg-light text-muted ms-3">F1</span>
+                    <span class="badge bg-light text-muted ms-3">F1</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 1, 1)">
                     8-cell
-                    <span class="float-end badge bg-light text-muted ms-3">F2</span>
+                    <span class="badge bg-light text-muted ms-3">F2</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 1, 2)">
                     16-cell
-                    <span class="float-end badge bg-light text-muted ms-3">F3</span>
+                    <span class="badge bg-light text-muted ms-3">F3</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 1, 3)">
                     24-cell
-                    <span class="float-end badge bg-light text-muted ms-3">F4</span>
+                    <span class="badge bg-light text-muted ms-3">F4</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 1, 4)">
                     120-cell
-                    <span class="float-end badge bg-light text-muted ms-3">F5</span>
+                    <span class="badge bg-light text-muted ms-3">F5</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 1, 5)">
                     600-cell
-                    <span class="float-end badge bg-light text-muted ms-3">F6</span>
+                    <span class="badge bg-light text-muted ms-3">F6</span>
                   </li>
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">duoprisms<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">duoprisms<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 2, 0)"> 3x3</li>
                   <li class="dropdown-item" onclick="Module.select(1, 2, 1)"> 4x4</li>
@@ -128,12 +138,12 @@
                   <li class="dropdown-item" onclick="Module.select(1, 2, 6)">12x12</li>
                   <li class="dropdown-item" onclick="Module.select(1, 2, 7)">
                     18x18
-                    <span class="float-end badge bg-light text-muted ms-3">F7</span>
+                    <span class="badge bg-light text-muted ms-3">F7</span>
                   </li>
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">truncated `hedra<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">truncated `hedra<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 3, 0)">t. tetra.</li>
                   <li class="dropdown-item" onclick="Module.select(1, 3, 1)">t. cube</li>
@@ -143,7 +153,7 @@
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">truncated `chora<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">truncated `chora<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 4, 0)">t. 5-cell</li>
                   <li class="dropdown-item" onclick="Module.select(1, 4, 1)">t. 16-cell</li>
@@ -151,25 +161,25 @@
                   <li class="dropdown-item" onclick="Module.select(1, 4, 3)">t. 24-cell</li>
                   <li class="dropdown-item" onclick="Module.select(1, 4, 4)">
                     t. 120-cell
-                    <span class="float-end badge bg-light text-muted ms-3">Shift + F3</span>
+                    <span class="badge bg-light text-muted ms-3">Shift + F3</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 4, 5)">t. 600-cell</li>
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">bitrunc. `chora<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">bitrunc. `chora<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 5, 0)">bt.. 5-cell</li>
                   <li class="dropdown-item" onclick="Module.select(1, 5, 1)">bt. 8-cell</li>
                   <li class="dropdown-item" onclick="Module.select(1, 5, 2)">bt. 24-cell</li>
                   <li class="dropdown-item" onclick="Module.select(1, 5, 3)">
                     bt. 120-cell
-                    <span class="float-end badge bg-light text-muted ms-3">Shift + F6</span>
+                    <span class="badge bg-light text-muted ms-3">Shift + F6</span>
                   </li>
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">edge-t. `hedra<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">edge-t. `hedra<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 6, 0)">e.t. tetra.</li>
                   <li class="dropdown-item" onclick="Module.select(1, 6, 1)">e.t. octa.</li>
@@ -179,7 +189,7 @@
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">edge-t. `chora<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">edge-t. `chora<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 7, 0)">e.t. 5-cell</li>
                   <li class="dropdown-item" onclick="Module.select(1, 7, 1)">e.t. 8-cell</li>
@@ -187,13 +197,13 @@
                   <li class="dropdown-item" onclick="Module.select(1, 7, 3)">e.t. 24-cell</li>
                   <li class="dropdown-item" onclick="Module.select(1, 7, 4)">
                     e.t. 120-cell
-                    <span class="float-end badge bg-light text-muted ms-3">Shift + F4</span>
+                    <span class="badge bg-light text-muted ms-3">Shift + F4</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 7, 5)">e.t. 600-cell</li>
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">cayley graphs<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">cayley graphs<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 8, 0)">2-2-2</li>
                   <li class="dropdown-item" onclick="Module.select(1, 8, 1)">2-2-3</li>
@@ -204,28 +214,28 @@
                   <li class="dropdown-item" onclick="Module.select(1, 8, 6)">2-3-5</li>
                   <li class="dropdown-item" onclick="Module.select(1, 8, 7)">
                     3-3-3
-                    <span class="float-end badge bg-light text-muted ms-3">F8</span>
+                    <span class="badge bg-light text-muted ms-3">F8</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 8, 8)">
                     Y
-                    <span class="float-end badge bg-light text-muted ms-3">F9</span>
+                    <span class="badge bg-light text-muted ms-3">F9</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 8, 9)">
                     3-3-4
-                    <span class="float-end badge bg-light text-muted ms-3">F10</span>
+                    <span class="badge bg-light text-muted ms-3">F10</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 8, 10)">
                     3-4-3
-                    <span class="float-end badge bg-light text-muted ms-3">F11</span>
+                    <span class="badge bg-light text-muted ms-3">F11</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 8, 11)">
                     3-3-5
-                    <span class="float-end badge bg-light text-muted ms-3">F12</span>
+                    <span class="badge bg-light text-muted ms-3">F12</span>
                   </li>
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">solids<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">solids<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 9, 0)">torus</li>
                   <li class="dropdown-item" onclick="Module.select(1, 9, 1)">cubes</li>
@@ -238,7 +248,7 @@
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">mazes<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">mazes<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 10, 0)">{3,5}</li>
                   <li class="dropdown-item" onclick="Module.select(1, 10, 1)">{3,3,3}</li>
@@ -251,7 +261,7 @@
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">222-family<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">222-family<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 11, 0)">2-2-2</li>
                   <li class="dropdown-item" onclick="Module.select(1, 11, 1)"> 1</li>
@@ -271,7 +281,7 @@
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">227-family<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">227-family<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 12, 0)">2-2-7</li>
                   <li class="dropdown-item" onclick="Module.select(1, 12, 1)"> 1</li>
@@ -291,7 +301,7 @@
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">233-family<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">233-family<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 13, 0)">2-3-3</li>
                   <li class="dropdown-item" onclick="Module.select(1, 13, 1)"> 1</li>
@@ -311,7 +321,7 @@
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">234-family<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">234-family<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 14, 0)">2-3-4</li>
                   <li class="dropdown-item" onclick="Module.select(1, 14, 1)"> 1</li>
@@ -331,7 +341,7 @@
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">235-family<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">235-family<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 15, 0)">2-3-5</li>
                   <li class="dropdown-item" onclick="Module.select(1, 15, 1)"> 1</li>
@@ -351,7 +361,7 @@
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item"> Y-family<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item"> Y-family<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 16, 0)"> Y</li>
                   <li class="dropdown-item" onclick="Module.select(1, 16, 1)"> 1</li>
@@ -371,7 +381,7 @@
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">333-family<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">333-family<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 17, 0)">3-3-3</li>
                   <li class="dropdown-item" onclick="Module.select(1, 17, 1)"> 1</li>
@@ -391,7 +401,7 @@
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">334-family<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">334-family<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 18, 0)">3-3-4</li>
                   <li class="dropdown-item" onclick="Module.select(1, 18, 1)"> 1</li>
@@ -411,7 +421,7 @@
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">343-family<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">343-family<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 19, 0)">3-4-3</li>
                   <li class="dropdown-item" onclick="Module.select(1, 19, 1)"> 1</li>
@@ -431,57 +441,57 @@
                 </ul>
               </li>
               <li>
-                <a class="dropdown-item">335-family<span class="float-end ms-2">»</span></a>
+                <a class="dropdown-item">335-family<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 20, 0)">3-3-5</li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 1)">
                     1
-                    <span class="float-end badge bg-light text-muted ms-3">Shift + F12</span>
+                    <span class="badge bg-light text-muted ms-3">Shift + F12</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 2)">
                     2
-                    <span class="float-end badge bg-light text-muted ms-3">Shift + F11</span>
+                    <span class="badge bg-light text-muted ms-3">Shift + F11</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 3)">
                     3
-                    <span class="float-end badge bg-light text-muted ms-3">Shift + F10</span>
+                    <span class="badge bg-light text-muted ms-3">Shift + F10</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 4)">
                     4
-                    <span class="float-end badge bg-light text-muted ms-3">Shift + F9</span>
+                    <span class="badge bg-light text-muted ms-3">Shift + F9</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 5)">
                     1,2
-                    <span class="float-end badge bg-light text-muted ms-3">Shift + F8</span>
+                    <span class="badge bg-light text-muted ms-3">Shift + F8</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 6)">
                     1,3
-                    <span class="float-end badge bg-light text-muted ms-3">Shift + F7</span>
+                    <span class="badge bg-light text-muted ms-3">Shift + F7</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 7)">
                     1,4
-                    <span class="float-end badge bg-light text-muted ms-3">Shift + F6</span>
+                    <span class="badge bg-light text-muted ms-3">Shift + F6</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 8)">
                     2,3
-                    <span class="float-end badge bg-light text-muted ms-3">Shift + F5</span>
+                    <span class="badge bg-light text-muted ms-3">Shift + F5</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 9)">
                     2,4
-                    <span class="float-end badge bg-light text-muted ms-3">Shift + F4</span>
+                    <span class="badge bg-light text-muted ms-3">Shift + F4</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 10)">
                     3,4
-                    <span class="float-end badge bg-light text-muted ms-3">Shift + F3</span>
+                    <span class="badge bg-light text-muted ms-3">Shift + F3</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 11)">1,2,3</li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 12)">
                     1,2,4
-                    <span class="float-end badge bg-light text-muted ms-3">Shift + F2</span>
+                    <span class="badge bg-light text-muted ms-3">Shift + F2</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 13)">
                     1,3,4
-                    <span class="float-end badge bg-light text-muted ms-3">Shift + F1</span>
+                    <span class="badge bg-light text-muted ms-3">Shift + F1</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 14)">2,3,4</li>
                 </ul>
@@ -492,139 +502,139 @@
             <hr class="dropdown-divider">
           </li>
           <li>
-            <a class="dropdown-item">View<span class="float-end ms-2">&raquo;</span></a>
+            <a class="dropdown-item">View<span class="ms-2">&raquo;</span></a>
             <ul class="submenu dropdown-menu">
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="toggle between mono and stereo"
                   onclick="Module.select(2, 0, -1)">
                 stereo/mono
-                <span class="float-end badge bg-light text-muted ms-3">1/2</span>
+                <span class="badge bg-light text-muted ms-3">1/2</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="see the model farther away"
                   onclick="Module.select(2, 1, -1)">
                 zoom out
-                <span class="float-end badge bg-light text-muted ms-3">&darr;</span>
+                <span class="badge bg-light text-muted ms-3">&darr;</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="see the model closer up"
                   onclick="Module.select(2, 2, -1)">
                 zoom in
-                <span class="float-end badge bg-light text-muted ms-3">&uarr;</span>
+                <span class="badge bg-light text-muted ms-3">&uarr;</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="move the camera to the left"
                   onclick="Module.select(2, 3, -1)">
                 pan left
-                <span class="float-end badge bg-light text-muted ms-3">Shift + &larr;</span>
+                <span class="badge bg-light text-muted ms-3">Shift + &larr;</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="move the camera to the right"
                   onclick="Module.select(2, 4, -1)">
                 pan right
-                <span class="float-end badge bg-light text-muted ms-3">Shift + &rarr;</span>
+                <span class="badge bg-light text-muted ms-3">Shift + &rarr;</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="move the camera up"
                   onclick="Module.select(2, 5, -1)">
                 pan up
-                <span class="float-end badge bg-light text-muted ms-3">Shift + &uarr;</span>
+                <span class="badge bg-light text-muted ms-3">Shift + &uarr;</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="move the camera down"
                   onclick="Module.select(2, 6, -1)">
                 pan down
-                <span class="float-end badge bg-light text-muted ms-3">Shift + &darr;</span>
+                <span class="badge bg-light text-muted ms-3">Shift + &darr;</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="adjust the camera to the center of the model"
                   onclick="Module.select(2, 7, -1)">
                 pan center
-                <span class="float-end badge bg-light text-muted ms-3">P</span>
+                <span class="badge bg-light text-muted ms-3">P</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="enter fullscreen"
                   onclick="Module.select(2, 8, -1)">
                 fullscreen
-                <span class="float-end badge bg-light text-muted ms-3">F</span>
+                <span class="badge bg-light text-muted ms-3">F</span>
               </li>
             </ul>
           </li>
           <li>
-            <a class="dropdown-item">Move<span class="float-end ms-2">&raquo;</span></a>
+            <a class="dropdown-item">Move<span class="ms-2">&raquo;</span></a>
             <ul class="submenu dropdown-menu">
               <!--
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="if you have a 1- or 2- button mouse, you can switch mouse channels"
                   onclick="Module.select(3, 0, -1)">
                 flip mouse
-                <span class="float-end badge bg-light text-muted ms-3">m</span>
+                <span class="badge bg-light text-muted ms-3">m</span>
               </li>
               -->
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="toggle drifting"
                   onclick="Module.select(3, 1, -1)">
                 drifting on/off
-                <span class="float-end badge bg-light text-muted ms-3">D</span>
+                <span class="badge bg-light text-muted ms-3">D</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="toggle the high/low drag to let the model float around freely"
                   onclick="Module.select(3, 2, -1)">
                 hi/lo drag
-                <span class="float-end badge bg-light text-muted ms-3">SPACE</span>
+                <span class="badge bg-light text-muted ms-3">SPACE</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="make the model spring to the center"
                   onclick="Module.select(3, 3, -1)">
                 springy
-                <span class="float-end badge bg-light text-muted ms-3">c</span>
+                <span class="badge bg-light text-muted ms-3">c</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="invert the spring"
                   onclick="Module.select(3, 4, -1)">
                 flip spring
-                <span class="float-end badge bg-light text-muted ms-3">i</span>
+                <span class="badge bg-light text-muted ms-3">i</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="set the springs center"
                   onclick="Module.select(3, 5, -1)">
                 tare spring
-                <span class="float-end badge bg-light text-muted ms-3">C</span>
+                <span class="badge bg-light text-muted ms-3">C</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="slow down movement"
                   onclick="Module.select(3, 6, -1)">
                 slower
-                <span class="float-end badge bg-light text-muted ms-3">s</span>
+                <span class="badge bg-light text-muted ms-3">s</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="speed up movement"
                   onclick="Module.select(3, 7, -1)">
                 faster
-                <span class="float-end badge bg-light text-muted ms-3">S</span>
+                <span class="badge bg-light text-muted ms-3">S</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="reset motion"
                   onclick="Module.select(3, 8, -1)">
                 reset
-                <span class="float-end badge bg-light text-muted ms-3">x</span>
+                <span class="badge bg-light text-muted ms-3">x</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="toggle pause"
                   onclick="Module.select(3, 9, -1)">
                 pause
-                <span class="float-end badge bg-light text-muted ms-3">p</span>
+                <span class="badge bg-light text-muted ms-3">p</span>
               </li>
             </ul>
           </li>
           <li>
-            <a class="dropdown-item">Fly<span class="float-end ms-2">&raquo;</span></a>
+            <a class="dropdown-item">Fly<span class="ms-2">&raquo;</span></a>
             <ul class="submenu dropdown-menu">
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="fly through a model"
                   onclick="Module.select(4, 0, -1)">
                 toggle flying
-                <span class="float-end badge bg-light text-muted ms-3">y</span>
+                <span class="badge bg-light text-muted ms-3">y</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="accelerate forward"
@@ -645,7 +655,7 @@
                   title="leave a trail ribbon"
                   onclick="Module.select(4, 4, -1)">
                 trail ribbon
-                <span class="float-end badge bg-light text-muted ms-3">t</span>
+                <span class="badge bg-light text-muted ms-3">t</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="leave a trail tube"
@@ -656,7 +666,7 @@
                   title="break a trail or start a new trail"
                   onclick="Module.select(4, 6, -1)">
                 break trail
-                <span class="float-end badge bg-light text-muted ms-3">T</span>
+                <span class="badge bg-light text-muted ms-3">T</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="pause trail"
@@ -671,66 +681,66 @@
             </ul>
           </li>
           <li>
-            <a class="dropdown-item">Style<span class="float-end ms-2">&raquo;</span></a>
+            <a class="dropdown-item">Style<span class="ms-2">&raquo;</span></a>
             <ul class="submenu dropdown-menu">
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="toggle faces"
                   onclick="Module.select(5, 0, -1)">
                 faces
-                <span class="float-end badge bg-light text-muted ms-3">f</span>
+                <span class="badge bg-light text-muted ms-3">f</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="toggle edges"
                   onclick="Module.select(5, 1, -1)">
                 edges
-                <span class="float-end badge bg-light text-muted ms-3">e</span>
+                <span class="badge bg-light text-muted ms-3">e</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="toggle vertices"
                   onclick="Module.select(5, 2, -1)">
                 vertices
-                <span class="float-end badge bg-light text-muted ms-3">v</span>
+                <span class="badge bg-light text-muted ms-3">v</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="very large models may look better in line-art style"
                   onclick="Module.select(5, 3, -1)">
                 line-art
-                <span class="float-end badge bg-light text-muted ms-3">h</span>
+                <span class="badge bg-light text-muted ms-3">h</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="toggle wireframe style"
                   onclick="Module.select(5, 4, -1)">
                 wireframe
-                <span class="float-end badge bg-light text-muted ms-3">w</span>
+                <span class="badge bg-light text-muted ms-3">w</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title=""
                   onclick="Module.select(5, 5, -1)">
                 thinner
-                <span class="float-end badge bg-light text-muted ms-3">-</span>
+                <span class="badge bg-light text-muted ms-3">-</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title=""
                   onclick="Module.select(5, 6, -1)">
                 fatter
-                <span class="float-end badge bg-light text-muted ms-3">+</span>
+                <span class="badge bg-light text-muted ms-3">+</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title=""
                   onclick="Module.select(5, 7, -1)">
                 fog
-                <span class="float-end badge bg-light text-muted ms-3">H</span>
+                <span class="badge bg-light text-muted ms-3">H</span>
               </li>
             </ul>
           </li>
           <li>
-            <a class="dropdown-item">Capture<span class="float-end ms-2">&raquo;</span></a>
+            <a class="dropdown-item">Capture<span class="ms-2">&raquo;</span></a>
             <ul class="submenu dropdown-menu">
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="toggles between coarse/fine meshes"
                   onclick="Module.select(6, 0, -1)">
                 toggle quality
-                <span class="float-end badge bg-light text-muted ms-3">q</span>
+                <span class="badge bg-light text-muted ms-3">q</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="capture a screenshot in the original resolution"
@@ -755,19 +765,19 @@
             </ul>
           </li>
           <li>
-            <a class="dropdown-item">Export<span class="float-end ms-2">&raquo;</span></a>
+            <a class="dropdown-item">Export<span class="ms-2">&raquo;</span></a>
             <ul class="submenu dropdown-menu">
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="exports geometry to the file jenn_export.stl"
                   onclick="Module.select(7, 0, -1)">
                 export to STL
-                <span class="float-end badge bg-light text-muted ms-3">g</span>
+                <span class="badge bg-light text-muted ms-3">g</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="toggles between coarse/fine meshes"
                   onclick="Module.select(7, 1, -1)">
                 toggle quality
-                <span class="float-end badge bg-light text-muted ms-3">q</span>
+                <span class="badge bg-light text-muted ms-3">q</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="increase min edge/vertex thickness for exported model"
@@ -783,7 +793,7 @@
                   title="exports graph to simple text file"
                   onclick="Module.select(7, 4, -1)">
                 export graph
-                <span class="float-end badge bg-light text-muted ms-3">G</span>
+                <span class="badge bg-light text-muted ms-3">G</span>
               </li>
             </ul>
           </li>
@@ -792,43 +802,42 @@
           </li>
 
           <li>
-            <div class="text-wrap px-3 pb-1">
-              <b>Drag behavior</b>
-            </div>
+            <h6 class="dropdown-header fw-bold">Drag behavior</h6>
 
-            <div class="dropdown-item text-decoration-underline" data-bs-toggle="tooltip" data-bs-placement="right"
+            <div class="dropdown-item active" data-bs-toggle="tooltip"
+                 data-bs-placement="right"
                  title="left-drag to rotate along the xz and yz direction, or steer direction in flying mode"
                  onclick="changeDragBehavior(0, this)" data-radio="drag">
               pitch &amp; yaw
-              <span class="float-end badge bg-light text-muted">Left</span>
+              <span class="badge bg-light text-muted ms-3">Left</span>
+            </div>
+
+            <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                 title="middle-drag or alt-drag to rotate along the zw and xy direction"
+                 onclick="changeDragBehavior(4, this)" data-radio="drag">
+              roll &amp; zw
+              <span class="badge bg-light text-muted ms-3">Mid / Alt</span>
             </div>
 
             <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                  title="right-drag or ctrl-drag to rotate along the xw and yw direction, or control speed in flying mode"
                  onclick="changeDragBehavior(2, this)" data-radio="drag">
               xw &amp; yw
-              <span class="float-end badge bg-light text-muted">Right/Ctrl</span>
-            </div>
-
-            <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                 title="middle-drag or alt-drag to rotate along the zw and xy direction"
-                 onclick="changeDragBehavior(4, this)" data-radio="drag">
-              zw &amp; roll
-              <span class="float-end badge bg-light text-muted">Mid/Alt</span>
+              <span class="badge bg-light text-muted ms-3">Right / Ctrl</span>
             </div>
 
             <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                  title="shift-drag to pan the image"
                  onclick="changeDragBehavior(1, this)" data-radio="drag">
               move
-              <span class="float-end badge bg-light text-muted">Shift</span>
+              <span class="badge bg-light text-muted ms-3">Shift</span>
             </div>
           </li>
 
         </ul>
       </nav>
     </aside>
-    <main class="col-xl-10" id="canvas-container">
+    <main class="col-xl" id="canvas-container">
       <canvas id="canvas" tabindex=-1 oncontextmenu="event.preventDefault()"></canvas>
     </main>
   </div>
@@ -940,8 +949,12 @@
   }
 
   // control drag behavior
-  const dragElems = document.querySelectorAll('[data-radio="drag"]');
+  let activeDrag = document.querySelector('.active[data-radio="drag"]');
   const changeDragBehavior = (key, el) => {
+    activeDrag.classList.remove("active");
+    el.classList.add("active");
+    activeDrag = el;
+
     GLUT.saveModifiers = (event) => {
       GLUT.modifiers = key;
       if (event['shiftKey'])
@@ -951,9 +964,6 @@
       if (event['altKey'])
         GLUT.modifiers = 4; /* GLUT_ACTIVE_ALT */
     }
-    const underline = "text-decoration-underline";
-    dragElems.forEach(e => e.classList.remove(underline));
-    el.classList.add(underline);
   }
 
   // wasm module

--- a/web/index.html
+++ b/web/index.html
@@ -75,7 +75,7 @@
     </div>
 
     <ul class="nav col-12 col-md-auto mb-2 justify-content-center mb-md-0">
-      <li><a href="https://jenn3d.org/" class="nav-link px-2 link-dark" target="_blank">Homepage</a></li>
+      <li><a href="https://jenn3d.org/" class="nav-link px-2 link-dark" target="_blank">Desktop</a></li>
       <li><a href="https://github.com/fritzo/jenn3d" class="nav-link px-2 link-dark" target="_blank">GitHub</a></li>
     </ul>
   </header>

--- a/web/index.html
+++ b/web/index.html
@@ -1024,17 +1024,21 @@
 
 <script>
   const triggerDownload = (url, filename) => {
-    const link = document.createElement('a');
-    link.download = filename;
-    link.href = url
-    link.click();
+    const anchor = document.createElement('a');
+    document.body.appendChild(anchor);
+    anchor.style.display = 'none';
+    anchor.download = filename;
+    anchor.href = url
+    anchor.click();
+    document.body.removeChild(anchor);
   }
 
   const saveFile = (filename) => {
     const data = FS.readFile(filename);
     const blob = new Blob([data], {'type': 'application/octet-stream'});
-    const url = window.URL.createObjectURL(blob);
+    const url = URL.createObjectURL(blob);
     triggerDownload(url, filename);
+    URL.revokeObjectURL(url);
   };
 
   const captureImage = (scaleFactor = 1) => {

--- a/web/index.html
+++ b/web/index.html
@@ -602,17 +602,23 @@
                   title="very large models may look better in line-art style"
                   onclick="Module.select(5, 3, -1)">
                 Line-art
-                <span class="badge bg-light text-muted ms-2">h</span>
+                <span class="badge bg-light text-muted ms-2">l</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle between curved lines and straight lines"
+                  onclick="Module.select(5, 4, -1)">
+                Curved
+                <span class="badge bg-light text-muted ms-2">L</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="toggle wireframe style"
-                  onclick="Module.select(5, 4, -1)">
+                  onclick="Module.select(5, 5, -1)">
                 Wireframe
                 <span class="badge bg-light text-muted ms-2">w</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="make the image look hazy"
-                  onclick="Module.select(5, 7, -1)">
+                  onclick="Module.select(5, 8, -1)">
                 Fog
                 <span class="badge bg-light text-muted ms-2">H</span>
               </li>
@@ -680,13 +686,13 @@
               <li><h6 class="dropdown-header">Thickness</h6></li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="Make the edges and vertices thinner"
-                  onclick="Module.select(5, 5, -1)">
+                  onclick="Module.select(5, 6, -1)">
                 Thinner
                 <span class="badge bg-light text-muted ms-2">-</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="Make the edges and vertices fatter"
-                  onclick="Module.select(5, 6, -1)">
+                  onclick="Module.select(5, 7, -1)">
                 Fatter
                 <span class="badge bg-light text-muted ms-2">+</span>
               </li>

--- a/web/index.html
+++ b/web/index.html
@@ -102,27 +102,27 @@
                 <ul class="submenu dropdown-menu">
                   <li class="dropdown-item" onclick="Module.select(1, 1, 0)">
                     5-cell
-                    <span class="badge bg-light text-muted ms-3">F1</span>
+                    <span class="badge bg-light text-muted ms-2">F1</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 1, 1)">
                     8-cell
-                    <span class="badge bg-light text-muted ms-3">F2</span>
+                    <span class="badge bg-light text-muted ms-2">F2</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 1, 2)">
                     16-cell
-                    <span class="badge bg-light text-muted ms-3">F3</span>
+                    <span class="badge bg-light text-muted ms-2">F3</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 1, 3)">
                     24-cell
-                    <span class="badge bg-light text-muted ms-3">F4</span>
+                    <span class="badge bg-light text-muted ms-2">F4</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 1, 4)">
                     120-cell
-                    <span class="badge bg-light text-muted ms-3">F5</span>
+                    <span class="badge bg-light text-muted ms-2">F5</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 1, 5)">
                     600-cell
-                    <span class="badge bg-light text-muted ms-3">F6</span>
+                    <span class="badge bg-light text-muted ms-2">F6</span>
                   </li>
                 </ul>
               </li>
@@ -138,7 +138,7 @@
                   <li class="dropdown-item" onclick="Module.select(1, 2, 6)">12x12</li>
                   <li class="dropdown-item" onclick="Module.select(1, 2, 7)">
                     18x18
-                    <span class="badge bg-light text-muted ms-3">F7</span>
+                    <span class="badge bg-light text-muted ms-2">F7</span>
                   </li>
                 </ul>
               </li>
@@ -161,7 +161,7 @@
                   <li class="dropdown-item" onclick="Module.select(1, 4, 3)">t. 24-cell</li>
                   <li class="dropdown-item" onclick="Module.select(1, 4, 4)">
                     t. 120-cell
-                    <span class="badge bg-light text-muted ms-3">Shift + F3</span>
+                    <span class="badge bg-light text-muted ms-2">Shift + F3</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 4, 5)">t. 600-cell</li>
                 </ul>
@@ -169,12 +169,12 @@
               <li>
                 <a class="dropdown-item">bitrunc. `chora<span class="ms-2">»</span></a>
                 <ul class="submenu dropdown-menu">
-                  <li class="dropdown-item" onclick="Module.select(1, 5, 0)">bt.. 5-cell</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 5, 0)">bt. 5-cell</li>
                   <li class="dropdown-item" onclick="Module.select(1, 5, 1)">bt. 8-cell</li>
                   <li class="dropdown-item" onclick="Module.select(1, 5, 2)">bt. 24-cell</li>
                   <li class="dropdown-item" onclick="Module.select(1, 5, 3)">
                     bt. 120-cell
-                    <span class="badge bg-light text-muted ms-3">Shift + F6</span>
+                    <span class="badge bg-light text-muted ms-2">Shift + F6</span>
                   </li>
                 </ul>
               </li>
@@ -197,7 +197,7 @@
                   <li class="dropdown-item" onclick="Module.select(1, 7, 3)">e.t. 24-cell</li>
                   <li class="dropdown-item" onclick="Module.select(1, 7, 4)">
                     e.t. 120-cell
-                    <span class="badge bg-light text-muted ms-3">Shift + F4</span>
+                    <span class="badge bg-light text-muted ms-2">Shift + F4</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 7, 5)">e.t. 600-cell</li>
                 </ul>
@@ -214,23 +214,23 @@
                   <li class="dropdown-item" onclick="Module.select(1, 8, 6)">2-3-5</li>
                   <li class="dropdown-item" onclick="Module.select(1, 8, 7)">
                     3-3-3
-                    <span class="badge bg-light text-muted ms-3">F8</span>
+                    <span class="badge bg-light text-muted ms-2">F8</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 8, 8)">
                     Y
-                    <span class="badge bg-light text-muted ms-3">F9</span>
+                    <span class="badge bg-light text-muted ms-2">F9</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 8, 9)">
                     3-3-4
-                    <span class="badge bg-light text-muted ms-3">F10</span>
+                    <span class="badge bg-light text-muted ms-2">F10</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 8, 10)">
                     3-4-3
-                    <span class="badge bg-light text-muted ms-3">F11</span>
+                    <span class="badge bg-light text-muted ms-2">F11</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 8, 11)">
                     3-3-5
-                    <span class="badge bg-light text-muted ms-3">F12</span>
+                    <span class="badge bg-light text-muted ms-2">F12</span>
                   </li>
                 </ul>
               </li>
@@ -446,52 +446,52 @@
                   <li class="dropdown-item" onclick="Module.select(1, 20, 0)">3-3-5</li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 1)">
                     1
-                    <span class="badge bg-light text-muted ms-3">Shift + F12</span>
+                    <span class="badge bg-light text-muted ms-2">Shift + F12</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 2)">
                     2
-                    <span class="badge bg-light text-muted ms-3">Shift + F11</span>
+                    <span class="badge bg-light text-muted ms-2">Shift + F11</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 3)">
                     3
-                    <span class="badge bg-light text-muted ms-3">Shift + F10</span>
+                    <span class="badge bg-light text-muted ms-2">Shift + F10</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 4)">
                     4
-                    <span class="badge bg-light text-muted ms-3">Shift + F9</span>
+                    <span class="badge bg-light text-muted ms-2">Shift + F9</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 5)">
                     1,2
-                    <span class="badge bg-light text-muted ms-3">Shift + F8</span>
+                    <span class="badge bg-light text-muted ms-2">Shift + F8</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 6)">
                     1,3
-                    <span class="badge bg-light text-muted ms-3">Shift + F7</span>
+                    <span class="badge bg-light text-muted ms-2">Shift + F7</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 7)">
                     1,4
-                    <span class="badge bg-light text-muted ms-3">Shift + F6</span>
+                    <span class="badge bg-light text-muted ms-2">Shift + F6</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 8)">
                     2,3
-                    <span class="badge bg-light text-muted ms-3">Shift + F5</span>
+                    <span class="badge bg-light text-muted ms-2">Shift + F5</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 9)">
                     2,4
-                    <span class="badge bg-light text-muted ms-3">Shift + F4</span>
+                    <span class="badge bg-light text-muted ms-2">Shift + F4</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 10)">
                     3,4
-                    <span class="badge bg-light text-muted ms-3">Shift + F3</span>
+                    <span class="badge bg-light text-muted ms-2">Shift + F3</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 11)">1,2,3</li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 12)">
                     1,2,4
-                    <span class="badge bg-light text-muted ms-3">Shift + F2</span>
+                    <span class="badge bg-light text-muted ms-2">Shift + F2</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 13)">
                     1,3,4
-                    <span class="badge bg-light text-muted ms-3">Shift + F1</span>
+                    <span class="badge bg-light text-muted ms-2">Shift + F1</span>
                   </li>
                   <li class="dropdown-item" onclick="Module.select(1, 20, 14)">2,3,4</li>
                 </ul>
@@ -504,296 +504,432 @@
           <li>
             <a class="dropdown-item">View<span class="ms-2">&raquo;</span></a>
             <ul class="submenu dropdown-menu">
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="toggle between mono and stereo"
-                  onclick="Module.select(2, 0, -1)">
-                stereo/mono
-                <span class="badge bg-light text-muted ms-3">1/2</span>
+
+              <li>
+                <h6 class="dropdown-header" data-bs-toggle="tooltip" data-bs-placement="right"
+                    title="You can also scroll or pinch to zoom">
+                  Zoom
+                </h6>
               </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="see the model farther away"
-                  onclick="Module.select(2, 1, -1)">
-                zoom out
-                <span class="badge bg-light text-muted ms-3">&darr;</span>
-              </li>
+
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="see the model closer up"
                   onclick="Module.select(2, 2, -1)">
-                zoom in
-                <span class="badge bg-light text-muted ms-3">&uarr;</span>
+                Zoom In
+                <span class="badge bg-light text-muted ms-2">&uarr;</span>
               </li>
+
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="see the model farther away"
+                  onclick="Module.select(2, 1, -1)">
+                Zoom Out
+                <span class="badge bg-light text-muted ms-2">&darr;</span>
+              </li>
+
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+
+              <li>
+                <h6 class="dropdown-header" data-bs-toggle="tooltip" data-bs-placement="right"
+                    title="You can also use shift-drag to pan the model">
+                  Panning
+                </h6>
+              </li>
+
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="move the camera to the left"
                   onclick="Module.select(2, 3, -1)">
-                pan left
-                <span class="badge bg-light text-muted ms-3">Shift + &larr;</span>
+                Pan Left
+                <span class="badge bg-light text-muted ms-2">Shift + &larr;</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="move the camera to the right"
                   onclick="Module.select(2, 4, -1)">
-                pan right
-                <span class="badge bg-light text-muted ms-3">Shift + &rarr;</span>
+                Pan Right
+                <span class="badge bg-light text-muted ms-2">Shift + &rarr;</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="move the camera up"
                   onclick="Module.select(2, 5, -1)">
-                pan up
-                <span class="badge bg-light text-muted ms-3">Shift + &uarr;</span>
+                Pan Up
+                <span class="badge bg-light text-muted ms-2">Shift + &uarr;</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="move the camera down"
                   onclick="Module.select(2, 6, -1)">
-                pan down
-                <span class="badge bg-light text-muted ms-3">Shift + &darr;</span>
+                Pan Down
+                <span class="badge bg-light text-muted ms-2">Shift + &darr;</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="adjust the camera to the center of the model"
                   onclick="Module.select(2, 7, -1)">
-                pan center
-                <span class="badge bg-light text-muted ms-3">P</span>
+                Pan Center
+                <span class="badge bg-light text-muted ms-2">P</span>
               </li>
+
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle between mono and stereo"
+                  onclick="Module.select(2, 0, -1)">
+                Stereo/Mono
+                <span class="badge bg-light text-muted ms-2">1/2</span>
+              </li>
+
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="enter fullscreen"
                   onclick="Module.select(2, 8, -1)">
-                fullscreen
-                <span class="badge bg-light text-muted ms-3">F</span>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a class="dropdown-item">Move<span class="ms-2">&raquo;</span></a>
-            <ul class="submenu dropdown-menu">
-              <!--
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="if you have a 1- or 2- button mouse, you can switch mouse channels"
-                  onclick="Module.select(3, 0, -1)">
-                flip mouse
-                <span class="badge bg-light text-muted ms-3">m</span>
-              </li>
-              -->
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="toggle drifting"
-                  onclick="Module.select(3, 1, -1)">
-                drifting on/off
-                <span class="badge bg-light text-muted ms-3">D</span>
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="toggle the high/low drag to let the model float around freely"
-                  onclick="Module.select(3, 2, -1)">
-                hi/lo drag
-                <span class="badge bg-light text-muted ms-3">SPACE</span>
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="make the model spring to the center"
-                  onclick="Module.select(3, 3, -1)">
-                springy
-                <span class="badge bg-light text-muted ms-3">c</span>
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="invert the spring"
-                  onclick="Module.select(3, 4, -1)">
-                flip spring
-                <span class="badge bg-light text-muted ms-3">i</span>
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="set the springs center"
-                  onclick="Module.select(3, 5, -1)">
-                tare spring
-                <span class="badge bg-light text-muted ms-3">C</span>
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="slow down movement"
-                  onclick="Module.select(3, 6, -1)">
-                slower
-                <span class="badge bg-light text-muted ms-3">s</span>
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="speed up movement"
-                  onclick="Module.select(3, 7, -1)">
-                faster
-                <span class="badge bg-light text-muted ms-3">S</span>
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="reset motion"
-                  onclick="Module.select(3, 8, -1)">
-                reset
-                <span class="badge bg-light text-muted ms-3">x</span>
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="toggle pause"
-                  onclick="Module.select(3, 9, -1)">
-                pause
-                <span class="badge bg-light text-muted ms-3">p</span>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a class="dropdown-item">Fly<span class="ms-2">&raquo;</span></a>
-            <ul class="submenu dropdown-menu">
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="fly through a model"
-                  onclick="Module.select(4, 0, -1)">
-                toggle flying
-                <span class="badge bg-light text-muted ms-3">y</span>
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="accelerate forward"
-                  onclick="Module.select(4, 1, -1)">
-                forward
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="accelerate backward"
-                  onclick="Module.select(4, 2, -1)">
-                backward
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="leave a trail line"
-                  onclick="Module.select(4, 3, -1)">
-                trail line
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="leave a trail ribbon"
-                  onclick="Module.select(4, 4, -1)">
-                trail ribbon
-                <span class="badge bg-light text-muted ms-3">t</span>
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="leave a trail tube"
-                  onclick="Module.select(4, 5, -1)">
-                trail tube
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="break a trail or start a new trail"
-                  onclick="Module.select(4, 6, -1)">
-                break trail
-                <span class="badge bg-light text-muted ms-3">T</span>
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="pause trail"
-                  onclick="Module.select(4, 7, -1)">
-                pause trail
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="toggle between hiding and displaying the model"
-                  onclick="Module.select(4, 8, -1)">
-                hide model
+                Fullscreen
+                <span class="badge bg-light text-muted ms-2">F</span>
               </li>
             </ul>
           </li>
           <li>
             <a class="dropdown-item">Style<span class="ms-2">&raquo;</span></a>
             <ul class="submenu dropdown-menu">
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="toggle faces"
-                  onclick="Module.select(5, 0, -1)">
-                faces
-                <span class="badge bg-light text-muted ms-3">f</span>
+
+              <li>
+                <h6 class="dropdown-header" data-bs-toggle="tooltip" data-bs-placement="right"
+                    title="The following effects can be combined">
+                  Effect
+                </h6>
               </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="toggle edges"
-                  onclick="Module.select(5, 1, -1)">
-                edges
-                <span class="badge bg-light text-muted ms-3">e</span>
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="toggle vertices"
-                  onclick="Module.select(5, 2, -1)">
-                vertices
-                <span class="badge bg-light text-muted ms-3">v</span>
-              </li>
+
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="very large models may look better in line-art style"
                   onclick="Module.select(5, 3, -1)">
-                line-art
-                <span class="badge bg-light text-muted ms-3">h</span>
+                Line-art
+                <span class="badge bg-light text-muted ms-2">h</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="toggle wireframe style"
                   onclick="Module.select(5, 4, -1)">
-                wireframe
-                <span class="badge bg-light text-muted ms-3">w</span>
+                Wireframe
+                <span class="badge bg-light text-muted ms-2">w</span>
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title=""
-                  onclick="Module.select(5, 5, -1)">
-                thinner
-                <span class="badge bg-light text-muted ms-3">-</span>
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title=""
-                  onclick="Module.select(5, 6, -1)">
-                fatter
-                <span class="badge bg-light text-muted ms-3">+</span>
-              </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title=""
+                  title="make the image look hazy"
                   onclick="Module.select(5, 7, -1)">
-                fog
-                <span class="badge bg-light text-muted ms-3">H</span>
+                Fog
+                <span class="badge bg-light text-muted ms-2">H</span>
+              </li>
+
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+
+              <li><h6 class="dropdown-header">Decompose</h6></li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="skipping back one frame"
+                  onclick="wasmTable.get(GLUT.specialFunc)(100)">
+                Backward
+                <span class="badge bg-light text-muted ms-2">&larr;</span>
+              </li>
+
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="moving forward one frame"
+                  onclick="wasmTable.get(GLUT.specialFunc)(102)">
+                Forward
+                <span class="badge bg-light text-muted ms-2">&rarr;</span>
+              </li>
+
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle outline when part of the model is hidden"
+                  onclick="wasmTable.get(GLUT.keyboardFunc)(100)">
+                Toggle Outline
+                <span class="badge bg-light text-muted ms-2">d</span>
+              </li>
+
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+
+              <li><h6 class="dropdown-header">Visibility</h6></li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle faces"
+                  onclick="Module.select(5, 0, -1)">
+                Faces
+                <span class="badge bg-light text-muted ms-2">f</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle edges"
+                  onclick="Module.select(5, 1, -1)">
+                Edges
+                <span class="badge bg-light text-muted ms-2">e</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle vertices"
+                  onclick="Module.select(5, 2, -1)">
+                Vertices
+                <span class="badge bg-light text-muted ms-2">v</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle between hiding and displaying the model"
+                  onclick="Module.select(4, 8, -1)">
+                Flip Visibility
+              </li>
+
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+
+
+              <li><h6 class="dropdown-header">Thickness</h6></li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="Make the edges and vertices thinner"
+                  onclick="Module.select(5, 5, -1)">
+                Thinner
+                <span class="badge bg-light text-muted ms-2">-</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="Make the edges and vertices fatter"
+                  onclick="Module.select(5, 6, -1)">
+                Fatter
+                <span class="badge bg-light text-muted ms-2">+</span>
+              </li>
+
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggles between coarse/fine meshes"
+                  onclick="Module.select(7, 1, -1)">
+                Toggle Quality
+                <span class="badge bg-light text-muted ms-2">q</span>
+              </li>
+
+            </ul>
+          </li>
+          <li>
+            <a class="dropdown-item">Motion<span class="ms-2">&raquo;</span></a>
+            <ul class="submenu dropdown-menu">
+              <li>
+                <h6 class="dropdown-header" data-bs-toggle="tooltip" data-bs-placement="right"
+                    title="Drifting is enabled at low strength by default.">
+                  Drifting
+                </h6>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle the high/low drifting strength to let the model float around freely"
+                  onclick="Module.select(3, 2, -1)">
+                Toggle Strength
+                <span class="badge bg-light text-muted ms-2">␣</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="drifting is on by default"
+                  onclick="Module.select(3, 1, -1)">
+                Toggle Drift
+                <span class="badge bg-light text-muted ms-2">D</span>
+              </li>
+
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+              <li>
+                <h6 class="dropdown-header" data-bs-toggle="tooltip" data-bs-placement="right"
+                    title="You need to move the model off the center to see the effect. ">
+                  Springy
+                </h6>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="make the model spring to the center"
+                  onclick="Module.select(3, 3, -1)">
+                Toggle Springy
+                <span class="badge bg-light text-muted ms-2">c</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="invert the spring"
+                  onclick="Module.select(3, 4, -1)">
+                Flip Spring
+                <span class="badge bg-light text-muted ms-2">i</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="set the springs center"
+                  onclick="Module.select(3, 5, -1)">
+                Tare Spring
+                <span class="badge bg-light text-muted ms-2">C</span>
+              </li>
+
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+              <li>
+                <h6 class="dropdown-header">Speed</h6>
+              </li>
+
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="slow down movement"
+                  onclick="Module.select(3, 6, -1)">
+                Slower
+                <span class="badge bg-light text-muted ms-2">s</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="speed up movement"
+                  onclick="Module.select(3, 7, -1)">
+                Faster
+                <span class="badge bg-light text-muted ms-2">S</span>
+              </li>
+
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="reset motion"
+                  onclick="Module.select(3, 8, -1)">
+                Reset
+                <span class="badge bg-light text-muted ms-2">x</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="pause motion"
+                  onclick="Module.select(3, 9, -1)">
+                Pause
+                <span class="badge bg-light text-muted ms-2">p</span>
               </li>
             </ul>
           </li>
           <li>
-            <a class="dropdown-item">Capture<span class="ms-2">&raquo;</span></a>
+            <a class="dropdown-item">Fly<span class="ms-2">&raquo;</span></a>
             <ul class="submenu dropdown-menu">
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="toggles between coarse/fine meshes"
-                  onclick="Module.select(6, 0, -1)">
-                toggle quality
-                <span class="badge bg-light text-muted ms-3">q</span>
+
+              <li>
+                <h6 class="dropdown-header" data-bs-toggle="tooltip" data-bs-placement="right"
+                    title="In flying mode, right-drag controls speed and left-drag steers direction.">
+                  Flying
+                </h6>
               </li>
+
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="fly through a model"
+                  onclick="Module.select(4, 0, -1)">
+                Toggle Flying
+                <span class="badge bg-light text-muted ms-2">y</span>
+              </li>
+
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="accelerate forward"
+                  onclick="Module.select(4, 1, -1)">
+                Fly Forward
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="accelerate backward"
+                  onclick="Module.select(4, 2, -1)">
+                Fly Backward
+              </li>
+
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+
+              <li><h6 class="dropdown-header">Trail</h6></li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="leave a trail line"
+                  onclick="Module.select(4, 3, -1)">
+                Trail Line
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="leave a trail ribbon"
+                  onclick="Module.select(4, 4, -1)">
+                Trail Ribbon
+                <span class="badge bg-light text-muted ms-2">t</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="leave a trail tube"
+                  onclick="Module.select(4, 5, -1)">
+                Trail Tube
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="break a trail or start a new trail"
+                  onclick="Module.select(4, 6, -1)">
+                Break Trail
+                <span class="badge bg-light text-muted ms-2">T</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="pause trail"
+                  onclick="Module.select(4, 7, -1)">
+                Pause Trail
+              </li>
+
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle between hiding and displaying the model"
+                  onclick="Module.select(4, 8, -1)">
+                Flip Visibility
+              </li>
+            </ul>
+          </li>
+
+          <li>
+            <a class="dropdown-item">Export<span class="ms-2">&raquo;</span></a>
+            <ul class="submenu dropdown-menu">
+              <li><h6 class="dropdown-header">Image</h6></li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="capture a screenshot in the original resolution"
                   onclick="captureImage()">
-                save 1x image
+                Save 1x Image
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="capture a screenshot with a scale factor of 2"
                   onclick="captureImage(2)">
-                save 2x image
+                Save 2x Image
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="capture a screenshot with a scale factor of 3"
                   onclick="captureImage(3)">
-                save 3x image
+                Save 3x Image
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="capture a screenshot with a scale factor of 4"
                   onclick="captureImage(4)">
-                save 4x image
+                Save 4x Image
               </li>
-            </ul>
-          </li>
-          <li>
-            <a class="dropdown-item">Export<span class="ms-2">&raquo;</span></a>
-            <ul class="submenu dropdown-menu">
+
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+              <li><h6 class="dropdown-header">3D Model</h6></li>
+
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="exports geometry to the file jenn_export.stl"
                   onclick="Module.select(7, 0, -1)">
-                export to STL
-                <span class="badge bg-light text-muted ms-3">g</span>
+                Export to STL
+                <span class="badge bg-light text-muted ms-2">g</span>
               </li>
-              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                  title="toggles between coarse/fine meshes"
-                  onclick="Module.select(7, 1, -1)">
-                toggle quality
-                <span class="badge bg-light text-muted ms-3">q</span>
-              </li>
+
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="increase min edge/vertex thickness for exported model"
                   onclick="Module.select(7, 2, -1)">
-                + min thickness
+                + Min Thickness
               </li>
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="decrease min edge/vertex thickness for exported model"
                   onclick="Module.select(7, 3, -1)">
-                - min thickness
+                - Min Thickness
               </li>
+
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="exports graph to simple text file"
                   onclick="Module.select(7, 4, -1)">
-                export graph
-                <span class="badge bg-light text-muted ms-3">G</span>
+                Export to Text
+                <span class="badge bg-light text-muted ms-2">G</span>
+              </li>
+
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggles between coarse/fine meshes"
+                  onclick="Module.select(7, 1, -1)">
+                Toggle Quality
+                <span class="badge bg-light text-muted ms-2">q</span>
               </li>
             </ul>
           </li>
@@ -802,34 +938,34 @@
             <hr class="dropdown-divider">
           </li>
           <li>
-            <h6 class="dropdown-header fw-bold">Quick Actions</h6>
+            <h6 class="dropdown-header">Quick Actions</h6>
 
             <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                  title="fly through a model"
                  onclick="Module.select(4, 0, -1)">
-              fly
-              <span class="badge bg-light text-muted ms-3">y</span>
+              Fly
+              <span class="badge bg-light text-muted ms-2">y</span>
             </div>
 
             <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                  title="toggle the high/low drag to let the model float around freely"
                  onclick="Module.select(3, 2, -1)">
-              drift
-              <span class="badge bg-light text-muted ms-3">SPACE</span>
+              Drift
+              <span class="badge bg-light text-muted ms-2">␣</span>
             </div>
 
             <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                  title="make the model spring to the center"
                  onclick="Module.select(3, 3, -1)">
-              springy
-              <span class="badge bg-light text-muted ms-3">c</span>
+              Springy
+              <span class="badge bg-light text-muted ms-2">c</span>
             </div>
 
             <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                  title="reset motion"
                  onclick="Module.select(3, 8, -1)">
-              reset
-              <span class="badge bg-light text-muted ms-3">x</span>
+              Reset
+              <span class="badge bg-light text-muted ms-2">x</span>
             </div>
           </li>
 
@@ -838,35 +974,35 @@
           </li>
 
           <li>
-            <h6 class="dropdown-header fw-bold">Drag Behavior</h6>
+            <h6 class="dropdown-header">Drag Behavior</h6>
 
             <div class="dropdown-item active" data-bs-toggle="tooltip"
                  data-bs-placement="right"
-                 title="left-drag to rotate along the xz and yz direction, or steer direction in flying mode"
+                 title="left-drag to rotate in the XZ and YZ plane, or steer direction in flying mode"
                  onclick="changeDragBehavior(0, this)" data-radio="drag">
-              pitch &amp; yaw
-              <span class="badge bg-light text-muted ms-3">Left</span>
+              Pitch / Yaw
+              <span class="badge bg-light text-muted ms-2">Left</span>
             </div>
 
             <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                 title="middle-drag or alt-drag to rotate along the zw and xy direction"
-                 onclick="changeDragBehavior(4, this)" data-radio="drag">
-              roll &amp; zw
-              <span class="badge bg-light text-muted ms-3">Mid / Alt</span>
-            </div>
-
-            <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                 title="right-drag or ctrl-drag to rotate along the xw and yw direction, or control speed in flying mode"
+                 title="right-drag or ctrl-drag to rotate in the XW and YW plane, or control speed in flying mode"
                  onclick="changeDragBehavior(2, this)" data-radio="drag">
-              xw &amp; yw
-              <span class="badge bg-light text-muted ms-3">Right / Ctrl</span>
+              XW / YW
+              <span class="badge bg-light text-muted ms-2">Right / Ctrl</span>
+            </div>
+
+            <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                 title="middle-drag or alt-drag to rotate in the ZW and XY plane"
+                 onclick="changeDragBehavior(4, this)" data-radio="drag">
+              Roll / ZW
+              <span class="badge bg-light text-muted ms-2">Middle / Alt</span>
             </div>
 
             <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                  title="shift-drag to pan the image"
                  onclick="changeDragBehavior(1, this)" data-radio="drag">
-              move
-              <span class="badge bg-light text-muted ms-3">Shift</span>
+              Move
+              <span class="badge bg-light text-muted ms-2">Shift</span>
             </div>
           </li>
 

--- a/web/index.html
+++ b/web/index.html
@@ -878,9 +878,9 @@
     }
 
     const dpi = window.devicePixelRatio;
-    const width = Module.canvas.clientWidth;
-    const size = Math.round(width * scaleFactor * dpi / 2);
-    return [size, size];
+    const aspectRatio = window.innerWidth < 1200 ? 4 / 3 : 3 / 4;
+    const width = Math.round(Module.canvas.clientWidth * scaleFactor * dpi / 2);
+    return [width, width * aspectRatio];
   }
 
   const resizeCanvas = (scaleFactor = 1) => {

--- a/web/index.html
+++ b/web/index.html
@@ -1,9 +1,10 @@
 <!doctypehtml>
-<html lang=en-us>
+<html lang=en-us class="h-100">
 
 <head>
   <meta charset=utf-8>
   <meta content="text/html; charset=utf-8" http-equiv=Content-Type>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/js/bootstrap.bundle.min.js"
@@ -32,6 +33,10 @@
         position: static !important;
         margin-left: 0.7rem; margin-right: 0.7rem; margin-bottom: .5rem;
       }
+
+      #canvas-container {
+        padding: 0;
+      }
     }
 
     .sidebar .dropdown-item {
@@ -40,779 +45,778 @@
 
     #canvas {
       cursor: grab;
+      touch-action: none;
+      width: 100%;
     }
   </style>
 </head>
 
-<body class="container">
+<body class="d-flex flex-column h-100">
 
-<header class="d-flex flex-wrap align-items-center justify-content-center justify-content-md-between py-3 mb-4 border-bottom">
-  <div class="d-flex align-items-center col-md-auto mb-2 mb-md-0">
-    <h2><a href="https://jenn3d.org/" class="text-dark text-decoration-none" target="_blank">
-      Jenn3D
-    </a></h2>
-    <div class="ps-3">
-      for visualizing 4D Coxeter polytopes
+<div class="container-xl">
+  <header class="d-flex flex-wrap align-items-center justify-content-center justify-content-md-between py-3 mb-4 border-bottom">
+    <div class="d-flex align-items-center col-md-auto mb-2 mb-md-0">
+      <h2><a href="https://jenn3d.org/" class="text-dark text-decoration-none" target="_blank">
+        Jenn3D
+      </a></h2>
+      <div class="ps-3">
+        for visualizing 4D Coxeter polytopes
+      </div>
     </div>
+
+    <ul class="nav col-12 col-md-auto mb-2 justify-content-center mb-md-0">
+      <li><a href="https://jenn3d.org/" class="nav-link px-2 link-dark" target="_blank">Homepage</a></li>
+      <li><a href="https://github.com/fritzo/jenn3d" class="nav-link px-2 link-dark" target="_blank">GitHub</a></li>
+    </ul>
+  </header>
+
+  <div class="row">
+    <aside class="col-xl-2">
+      <nav class="sidebar card py-2 mb-4">
+        <ul class="nav flex-column">
+          <li>
+            <a class="dropdown-item">Model<span class="float-end ms-2">»</span></a>
+            <ul class="submenu dropdown-menu">
+              <li>
+                <a class="dropdown-item">polyhedra<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 0, 0)">tetrahedron</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 0, 1)">cube</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 0, 2)">octahedron</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 0, 3)">dodecahedron</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 0, 4)">icosahedron</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">polychora<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 1, 0)">
+                    5-cell
+                    <span class="float-end badge bg-light text-muted ms-3">F1</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 1, 1)">
+                    8-cell
+                    <span class="float-end badge bg-light text-muted ms-3">F2</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 1, 2)">
+                    16-cell
+                    <span class="float-end badge bg-light text-muted ms-3">F3</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 1, 3)">
+                    24-cell
+                    <span class="float-end badge bg-light text-muted ms-3">F4</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 1, 4)">
+                    120-cell
+                    <span class="float-end badge bg-light text-muted ms-3">F5</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 1, 5)">
+                    600-cell
+                    <span class="float-end badge bg-light text-muted ms-3">F6</span>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">duoprisms<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 2, 0)"> 3x3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 2, 1)"> 4x4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 2, 2)"> 4x5</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 2, 3)"> 4x6</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 2, 4)"> 5x5</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 2, 5)"> 4x10</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 2, 6)">12x12</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 2, 7)">
+                    18x18
+                    <span class="float-end badge bg-light text-muted ms-3">F7</span>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">truncated `hedra<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 3, 0)">t. tetra.</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 3, 1)">t. cube</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 3, 2)">t. octa.</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 3, 3)">t. dodeca.</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 3, 4)">t. icosa.</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">truncated `chora<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 4, 0)">t. 5-cell</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 4, 1)">t. 16-cell</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 4, 2)">t. 8-cell</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 4, 3)">t. 24-cell</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 4, 4)">
+                    t. 120-cell
+                    <span class="float-end badge bg-light text-muted ms-3">Shift + F3</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 4, 5)">t. 600-cell</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">bitrunc. `chora<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 5, 0)">bt.. 5-cell</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 5, 1)">bt. 8-cell</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 5, 2)">bt. 24-cell</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 5, 3)">
+                    bt. 120-cell
+                    <span class="float-end badge bg-light text-muted ms-3">Shift + F6</span>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">edge-t. `hedra<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 6, 0)">e.t. tetra.</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 6, 1)">e.t. octa.</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 6, 2)">e.t. cube</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 6, 3)">e.t. dodeca.</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 6, 4)">e.t. icosa.</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">edge-t. `chora<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 7, 0)">e.t. 5-cell</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 7, 1)">e.t. 8-cell</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 7, 2)">e.t. 16-cell</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 7, 3)">e.t. 24-cell</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 7, 4)">
+                    e.t. 120-cell
+                    <span class="float-end badge bg-light text-muted ms-3">Shift + F4</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 7, 5)">e.t. 600-cell</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">cayley graphs<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 8, 0)">2-2-2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 8, 1)">2-2-3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 8, 2)">2-2-5</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 8, 3)">2-2-9</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 8, 4)">2-3-3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 8, 5)">2-3-4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 8, 6)">2-3-5</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 8, 7)">
+                    3-3-3
+                    <span class="float-end badge bg-light text-muted ms-3">F8</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 8, 8)">
+                    Y
+                    <span class="float-end badge bg-light text-muted ms-3">F9</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 8, 9)">
+                    3-3-4
+                    <span class="float-end badge bg-light text-muted ms-3">F10</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 8, 10)">
+                    3-4-3
+                    <span class="float-end badge bg-light text-muted ms-3">F11</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 8, 11)">
+                    3-3-5
+                    <span class="float-end badge bg-light text-muted ms-3">F12</span>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">solids<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 9, 0)">torus</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 9, 1)">cubes</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 9, 2)">8-hedra</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 9, 3)">12-hedra</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 9, 4)">20-hedra</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 9, 5)">4-hedra</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 9, 6)">6-prisms</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 9, 7)">8-prisms</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">mazes<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 10, 0)">{3,5}</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 10, 1)">{3,3,3}</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 10, 2)">{3,3,4}</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 10, 3)">{3,4,3}</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 10, 4)">{3,3,5}a</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 10, 5)">{3,3,5}b</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 10, 6)">{3,3,5}c</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 10, 7)">{3,3,5}d</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">222-family<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 11, 0)">2-2-2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 11, 1)"> 1</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 11, 2)"> 2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 11, 3)"> 3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 11, 4)"> 4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 11, 5)"> 1,2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 11, 6)"> 1,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 11, 7)"> 1,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 11, 8)"> 2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 11, 9)"> 2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 11, 10)"> 3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 11, 11)">1,2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 11, 12)">1,2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 11, 13)">1,3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 11, 14)">2,3,4</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">227-family<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 12, 0)">2-2-7</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 12, 1)"> 1</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 12, 2)"> 2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 12, 3)"> 3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 12, 4)"> 4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 12, 5)"> 1,2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 12, 6)"> 1,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 12, 7)"> 1,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 12, 8)"> 2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 12, 9)"> 2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 12, 10)"> 3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 12, 11)">1,2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 12, 12)">1,2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 12, 13)">1,3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 12, 14)">2,3,4</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">233-family<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 13, 0)">2-3-3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 13, 1)"> 1</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 13, 2)"> 2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 13, 3)"> 3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 13, 4)"> 4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 13, 5)"> 1,2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 13, 6)"> 1,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 13, 7)"> 1,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 13, 8)"> 2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 13, 9)"> 2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 13, 10)"> 3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 13, 11)">1,2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 13, 12)">1,2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 13, 13)">1,3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 13, 14)">2,3,4</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">234-family<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 14, 0)">2-3-4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 14, 1)"> 1</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 14, 2)"> 2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 14, 3)"> 3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 14, 4)"> 4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 14, 5)"> 1,2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 14, 6)"> 1,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 14, 7)"> 1,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 14, 8)"> 2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 14, 9)"> 2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 14, 10)"> 3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 14, 11)">1,2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 14, 12)">1,2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 14, 13)">1,3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 14, 14)">2,3,4</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">235-family<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 15, 0)">2-3-5</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 15, 1)"> 1</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 15, 2)"> 2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 15, 3)"> 3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 15, 4)"> 4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 15, 5)"> 1,2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 15, 6)"> 1,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 15, 7)"> 1,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 15, 8)"> 2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 15, 9)"> 2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 15, 10)"> 3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 15, 11)">1,2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 15, 12)">1,2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 15, 13)">1,3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 15, 14)">2,3,4</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item"> Y-family<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 16, 0)"> Y</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 16, 1)"> 1</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 16, 2)"> 2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 16, 3)"> 3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 16, 4)"> 4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 16, 5)"> 1,2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 16, 6)"> 1,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 16, 7)"> 1,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 16, 8)"> 2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 16, 9)"> 2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 16, 10)"> 3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 16, 11)">1,2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 16, 12)">1,2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 16, 13)">1,3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 16, 14)">2,3,4</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">333-family<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 17, 0)">3-3-3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 17, 1)"> 1</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 17, 2)"> 2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 17, 3)"> 3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 17, 4)"> 4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 17, 5)"> 1,2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 17, 6)"> 1,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 17, 7)"> 1,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 17, 8)"> 2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 17, 9)"> 2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 17, 10)"> 3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 17, 11)">1,2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 17, 12)">1,2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 17, 13)">1,3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 17, 14)">2,3,4</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">334-family<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 18, 0)">3-3-4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 18, 1)"> 1</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 18, 2)"> 2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 18, 3)"> 3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 18, 4)"> 4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 18, 5)"> 1,2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 18, 6)"> 1,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 18, 7)"> 1,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 18, 8)"> 2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 18, 9)"> 2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 18, 10)"> 3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 18, 11)">1,2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 18, 12)">1,2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 18, 13)">1,3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 18, 14)">2,3,4</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">343-family<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 19, 0)">3-4-3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 19, 1)"> 1</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 19, 2)"> 2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 19, 3)"> 3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 19, 4)"> 4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 19, 5)"> 1,2</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 19, 6)"> 1,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 19, 7)"> 1,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 19, 8)"> 2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 19, 9)"> 2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 19, 10)"> 3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 19, 11)">1,2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 19, 12)">1,2,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 19, 13)">1,3,4</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 19, 14)">2,3,4</li>
+                </ul>
+              </li>
+              <li>
+                <a class="dropdown-item">335-family<span class="float-end ms-2">»</span></a>
+                <ul class="submenu dropdown-menu">
+                  <li class="dropdown-item" onclick="Module.select(1, 20, 0)">3-3-5</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 20, 1)">
+                    1
+                    <span class="float-end badge bg-light text-muted ms-3">Shift + F12</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 20, 2)">
+                    2
+                    <span class="float-end badge bg-light text-muted ms-3">Shift + F11</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 20, 3)">
+                    3
+                    <span class="float-end badge bg-light text-muted ms-3">Shift + F10</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 20, 4)">
+                    4
+                    <span class="float-end badge bg-light text-muted ms-3">Shift + F9</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 20, 5)">
+                    1,2
+                    <span class="float-end badge bg-light text-muted ms-3">Shift + F8</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 20, 6)">
+                    1,3
+                    <span class="float-end badge bg-light text-muted ms-3">Shift + F7</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 20, 7)">
+                    1,4
+                    <span class="float-end badge bg-light text-muted ms-3">Shift + F6</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 20, 8)">
+                    2,3
+                    <span class="float-end badge bg-light text-muted ms-3">Shift + F5</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 20, 9)">
+                    2,4
+                    <span class="float-end badge bg-light text-muted ms-3">Shift + F4</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 20, 10)">
+                    3,4
+                    <span class="float-end badge bg-light text-muted ms-3">Shift + F3</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 20, 11)">1,2,3</li>
+                  <li class="dropdown-item" onclick="Module.select(1, 20, 12)">
+                    1,2,4
+                    <span class="float-end badge bg-light text-muted ms-3">Shift + F2</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 20, 13)">
+                    1,3,4
+                    <span class="float-end badge bg-light text-muted ms-3">Shift + F1</span>
+                  </li>
+                  <li class="dropdown-item" onclick="Module.select(1, 20, 14)">2,3,4</li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <hr class="dropdown-divider">
+          </li>
+          <li>
+            <a class="dropdown-item">View<span class="float-end ms-2">&raquo;</span></a>
+            <ul class="submenu dropdown-menu">
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle between mono and stereo"
+                  onclick="Module.select(2, 0, -1)">
+                stereo/mono
+                <span class="float-end badge bg-light text-muted ms-3">1/2</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="see the model farther away"
+                  onclick="Module.select(2, 1, -1)">
+                zoom out
+                <span class="float-end badge bg-light text-muted ms-3">&darr;</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="see the model closer up"
+                  onclick="Module.select(2, 2, -1)">
+                zoom in
+                <span class="float-end badge bg-light text-muted ms-3">&uarr;</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="move the camera to the left"
+                  onclick="Module.select(2, 3, -1)">
+                pan left
+                <span class="float-end badge bg-light text-muted ms-3">Shift + &larr;</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="move the camera to the right"
+                  onclick="Module.select(2, 4, -1)">
+                pan right
+                <span class="float-end badge bg-light text-muted ms-3">Shift + &rarr;</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="move the camera up"
+                  onclick="Module.select(2, 5, -1)">
+                pan up
+                <span class="float-end badge bg-light text-muted ms-3">Shift + &uarr;</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="move the camera down"
+                  onclick="Module.select(2, 6, -1)">
+                pan down
+                <span class="float-end badge bg-light text-muted ms-3">Shift + &darr;</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="adjust the camera to the center of the model"
+                  onclick="Module.select(2, 7, -1)">
+                pan center
+                <span class="float-end badge bg-light text-muted ms-3">P</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="enter fullscreen"
+                  onclick="Module.select(2, 8, -1)">
+                fullscreen
+                <span class="float-end badge bg-light text-muted ms-3">F</span>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <a class="dropdown-item">Move<span class="float-end ms-2">&raquo;</span></a>
+            <ul class="submenu dropdown-menu">
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="if you have a 1- or 2- button mouse, you can switch mouse channels"
+                  onclick="Module.select(3, 0, -1)">
+                flip mouse
+                <span class="float-end badge bg-light text-muted ms-3">m</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle drifting"
+                  onclick="Module.select(3, 1, -1)">
+                drifting on/off
+                <span class="float-end badge bg-light text-muted ms-3">D</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle the high/low drag to let the model float around freely"
+                  onclick="Module.select(3, 2, -1)">
+                hi/lo drag
+                <span class="float-end badge bg-light text-muted ms-3">SPACE</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="make the model spring to the center"
+                  onclick="Module.select(3, 3, -1)">
+                springy
+                <span class="float-end badge bg-light text-muted ms-3">c</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="invert the spring"
+                  onclick="Module.select(3, 4, -1)">
+                flip spring
+                <span class="float-end badge bg-light text-muted ms-3">i</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="set the springs center"
+                  onclick="Module.select(3, 5, -1)">
+                tare spring
+                <span class="float-end badge bg-light text-muted ms-3">C</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="slow down movement"
+                  onclick="Module.select(3, 6, -1)">
+                slower
+                <span class="float-end badge bg-light text-muted ms-3">s</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="speed up movement"
+                  onclick="Module.select(3, 7, -1)">
+                faster
+                <span class="float-end badge bg-light text-muted ms-3">S</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="reset motion"
+                  onclick="Module.select(3, 8, -1)">
+                reset
+                <span class="float-end badge bg-light text-muted ms-3">x</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle pause"
+                  onclick="Module.select(3, 9, -1)">
+                pause
+                <span class="float-end badge bg-light text-muted ms-3">p</span>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <a class="dropdown-item">Fly<span class="float-end ms-2">&raquo;</span></a>
+            <ul class="submenu dropdown-menu">
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="fly through a model"
+                  onclick="Module.select(4, 0, -1)">
+                toggle flying
+                <span class="float-end badge bg-light text-muted ms-3">y</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="accelerate forward"
+                  onclick="Module.select(4, 1, -1)">
+                forward
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="accelerate backward"
+                  onclick="Module.select(4, 2, -1)">
+                backward
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="leave a trail line"
+                  onclick="Module.select(4, 3, -1)">
+                trail line
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="leave a trail ribbon"
+                  onclick="Module.select(4, 4, -1)">
+                trail ribbon
+                <span class="float-end badge bg-light text-muted ms-3">t</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="leave a trail tube"
+                  onclick="Module.select(4, 5, -1)">
+                trail tube
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="break a trail or start a new trail"
+                  onclick="Module.select(4, 6, -1)">
+                break trail
+                <span class="float-end badge bg-light text-muted ms-3">T</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="pause trail"
+                  onclick="Module.select(4, 7, -1)">
+                pause trail
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle between hiding and displaying the model"
+                  onclick="Module.select(4, 8, -1)">
+                hide model
+              </li>
+            </ul>
+          </li>
+          <li>
+            <a class="dropdown-item">Style<span class="float-end ms-2">&raquo;</span></a>
+            <ul class="submenu dropdown-menu">
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle faces"
+                  onclick="Module.select(5, 0, -1)">
+                faces
+                <span class="float-end badge bg-light text-muted ms-3">f</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle edges"
+                  onclick="Module.select(5, 1, -1)">
+                edges
+                <span class="float-end badge bg-light text-muted ms-3">e</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle vertices"
+                  onclick="Module.select(5, 2, -1)">
+                vertices
+                <span class="float-end badge bg-light text-muted ms-3">v</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="very large models may look better in line-art style"
+                  onclick="Module.select(5, 3, -1)">
+                line-art
+                <span class="float-end badge bg-light text-muted ms-3">h</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggle wireframe style"
+                  onclick="Module.select(5, 4, -1)">
+                wireframe
+                <span class="float-end badge bg-light text-muted ms-3">w</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title=""
+                  onclick="Module.select(5, 5, -1)">
+                thinner
+                <span class="float-end badge bg-light text-muted ms-3">-</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title=""
+                  onclick="Module.select(5, 6, -1)">
+                fatter
+                <span class="float-end badge bg-light text-muted ms-3">+</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title=""
+                  onclick="Module.select(5, 7, -1)">
+                fog
+                <span class="float-end badge bg-light text-muted ms-3">H</span>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <a class="dropdown-item">Capture<span class="float-end ms-2">&raquo;</span></a>
+            <ul class="submenu dropdown-menu">
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggles between coarse/fine meshes"
+                  onclick="Module.select(6, 0, -1)">
+                toggle quality
+                <span class="float-end badge bg-light text-muted ms-3">q</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="capture a screenshot in the original resolution"
+                  onclick="captureImage()">
+                save 1x image
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="capture a screenshot with a scale factor of 2"
+                  onclick="captureImage(2)">
+                save 2x image
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="capture a screenshot with a scale factor of 3"
+                  onclick="captureImage(3)">
+                save 3x image
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="capture a screenshot with a scale factor of 4"
+                  onclick="captureImage(4)">
+                save 4x image
+              </li>
+            </ul>
+          </li>
+
+          <li>
+            <a class="dropdown-item">Export<span class="float-end ms-2">&raquo;</span></a>
+            <ul class="submenu dropdown-menu">
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="exports geometry to the file jenn_export.stl"
+                  onclick="Module.select(7, 0, -1)">
+                export to STL
+                <span class="float-end badge bg-light text-muted ms-3">g</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="toggles between coarse/fine meshes"
+                  onclick="Module.select(7, 1, -1)">
+                toggle quality
+                <span class="float-end badge bg-light text-muted ms-3">q</span>
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="increase min edge/vertex thickness for exported model"
+                  onclick="Module.select(7, 2, -1)">
+                + min thickness
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="decrease min edge/vertex thickness for exported model"
+                  onclick="Module.select(7, 3, -1)">
+                - min thickness
+              </li>
+              <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                  title="exports graph to simple text file"
+                  onclick="Module.select(7, 4, -1)">
+                export graph
+                <span class="float-end badge bg-light text-muted ms-3">G</span>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <hr class="dropdown-divider">
+          </li>
+          <li>
+            <div class="text-muted text-wrap px-3">
+              <div class="py-1">
+                <b>Rotate</b> <br> Drag with a 3-btn mouse (or ctrl-drag &amp; alt-drag)
+              </div>
+              <div class="py-1">
+                <b>Pan</b> <br> Shift-drag to pan<br>
+              </div>
+              <div class="py-1">
+                <b>In flying mode</b> <br> Right-drag controls speed <br> Left-drag steers direction
+              </div>
+            </div>
+          </li>
+        </ul>
+      </nav>
+    </aside>
+    <main class="col-xl-10" id="canvas-container">
+      <canvas id="canvas" tabindex=-1 oncontextmenu="event.preventDefault()"></canvas>
+    </main>
   </div>
-
-  <ul class="nav col-12 col-md-auto mb-2 justify-content-center mb-md-0">
-    <li><a href="https://jenn3d.org/" class="nav-link px-2 link-dark" target="_blank">Homepage</a></li>
-    <li><a href="https://github.com/fritzo/jenn3d" class="nav-link px-2 link-dark" target="_blank">GitHub</a></li>
-  </ul>
-</header>
-
-<div class="row">
-  <aside class="col-xl-2">
-    <nav class="sidebar card py-2 mb-4">
-      <ul class="nav flex-column">
-        <li data-bs-toggle="tooltip" data-bs-placement="top"
-            title="F1-F12 select a basic model; Shift + F1-F12 select a complicated model">
-          <a class="dropdown-item">Model<span class="float-end ms-2">»</span></a>
-          <ul class="submenu dropdown-menu">
-            <li>
-              <a class="dropdown-item">polyhedra<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 0, 0)">tetrahedron</li>
-                <li class="dropdown-item" onclick="Module.select(1, 0, 1)">cube</li>
-                <li class="dropdown-item" onclick="Module.select(1, 0, 2)">octahedron</li>
-                <li class="dropdown-item" onclick="Module.select(1, 0, 3)">dodecahedron</li>
-                <li class="dropdown-item" onclick="Module.select(1, 0, 4)">icosahedron</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">polychora<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 1, 0)">
-                  5-cell
-                  <span class="float-end badge bg-light text-muted ms-3">F1</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 1, 1)">
-                  8-cell
-                  <span class="float-end badge bg-light text-muted ms-3">F2</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 1, 2)">
-                  16-cell
-                  <span class="float-end badge bg-light text-muted ms-3">F3</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 1, 3)">
-                  24-cell
-                  <span class="float-end badge bg-light text-muted ms-3">F4</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 1, 4)">
-                  120-cell
-                  <span class="float-end badge bg-light text-muted ms-3">F5</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 1, 5)">
-                  600-cell
-                  <span class="float-end badge bg-light text-muted ms-3">F6</span>
-                </li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">duoprisms<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 2, 0)"> 3x3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 2, 1)"> 4x4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 2, 2)"> 4x5</li>
-                <li class="dropdown-item" onclick="Module.select(1, 2, 3)"> 4x6</li>
-                <li class="dropdown-item" onclick="Module.select(1, 2, 4)"> 5x5</li>
-                <li class="dropdown-item" onclick="Module.select(1, 2, 5)"> 4x10</li>
-                <li class="dropdown-item" onclick="Module.select(1, 2, 6)">12x12</li>
-                <li class="dropdown-item" onclick="Module.select(1, 2, 7)">
-                  18x18
-                  <span class="float-end badge bg-light text-muted ms-3">F7</span>
-                </li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">truncated `hedra<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 3, 0)">t. tetra.</li>
-                <li class="dropdown-item" onclick="Module.select(1, 3, 1)">t. cube</li>
-                <li class="dropdown-item" onclick="Module.select(1, 3, 2)">t. octa.</li>
-                <li class="dropdown-item" onclick="Module.select(1, 3, 3)">t. dodeca.</li>
-                <li class="dropdown-item" onclick="Module.select(1, 3, 4)">t. icosa.</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">truncated `chora<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 4, 0)">t. 5-cell</li>
-                <li class="dropdown-item" onclick="Module.select(1, 4, 1)">t. 16-cell</li>
-                <li class="dropdown-item" onclick="Module.select(1, 4, 2)">t. 8-cell</li>
-                <li class="dropdown-item" onclick="Module.select(1, 4, 3)">t. 24-cell</li>
-                <li class="dropdown-item" onclick="Module.select(1, 4, 4)">
-                  t. 120-cell
-                  <span class="float-end badge bg-light text-muted ms-3">Shift + F3</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 4, 5)">t. 600-cell</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">bitrunc. `chora<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 5, 0)">bt.. 5-cell</li>
-                <li class="dropdown-item" onclick="Module.select(1, 5, 1)">bt. 8-cell</li>
-                <li class="dropdown-item" onclick="Module.select(1, 5, 2)">bt. 24-cell</li>
-                <li class="dropdown-item" onclick="Module.select(1, 5, 3)">
-                  bt. 120-cell
-                  <span class="float-end badge bg-light text-muted ms-3">Shift + F6</span>
-                </li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">edge-t. `hedra<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 6, 0)">e.t. tetra.</li>
-                <li class="dropdown-item" onclick="Module.select(1, 6, 1)">e.t. octa.</li>
-                <li class="dropdown-item" onclick="Module.select(1, 6, 2)">e.t. cube</li>
-                <li class="dropdown-item" onclick="Module.select(1, 6, 3)">e.t. dodeca.</li>
-                <li class="dropdown-item" onclick="Module.select(1, 6, 4)">e.t. icosa.</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">edge-t. `chora<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 7, 0)">e.t. 5-cell</li>
-                <li class="dropdown-item" onclick="Module.select(1, 7, 1)">e.t. 8-cell</li>
-                <li class="dropdown-item" onclick="Module.select(1, 7, 2)">e.t. 16-cell</li>
-                <li class="dropdown-item" onclick="Module.select(1, 7, 3)">e.t. 24-cell</li>
-                <li class="dropdown-item" onclick="Module.select(1, 7, 4)">
-                  e.t. 120-cell
-                  <span class="float-end badge bg-light text-muted ms-3">Shift + F4</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 7, 5)">e.t. 600-cell</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">cayley graphs<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 8, 0)">2-2-2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 8, 1)">2-2-3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 8, 2)">2-2-5</li>
-                <li class="dropdown-item" onclick="Module.select(1, 8, 3)">2-2-9</li>
-                <li class="dropdown-item" onclick="Module.select(1, 8, 4)">2-3-3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 8, 5)">2-3-4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 8, 6)">2-3-5</li>
-                <li class="dropdown-item" onclick="Module.select(1, 8, 7)">
-                  3-3-3
-                  <span class="float-end badge bg-light text-muted ms-3">F8</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 8, 8)">
-                  Y
-                  <span class="float-end badge bg-light text-muted ms-3">F9</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 8, 9)">
-                  3-3-4
-                  <span class="float-end badge bg-light text-muted ms-3">F10</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 8, 10)">
-                  3-4-3
-                  <span class="float-end badge bg-light text-muted ms-3">F11</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 8, 11)">
-                  3-3-5
-                  <span class="float-end badge bg-light text-muted ms-3">F12</span>
-                </li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">solids<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 9, 0)">torus</li>
-                <li class="dropdown-item" onclick="Module.select(1, 9, 1)">cubes</li>
-                <li class="dropdown-item" onclick="Module.select(1, 9, 2)">8-hedra</li>
-                <li class="dropdown-item" onclick="Module.select(1, 9, 3)">12-hedra</li>
-                <li class="dropdown-item" onclick="Module.select(1, 9, 4)">20-hedra</li>
-                <li class="dropdown-item" onclick="Module.select(1, 9, 5)">4-hedra</li>
-                <li class="dropdown-item" onclick="Module.select(1, 9, 6)">6-prisms</li>
-                <li class="dropdown-item" onclick="Module.select(1, 9, 7)">8-prisms</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">mazes<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 10, 0)">{3,5}</li>
-                <li class="dropdown-item" onclick="Module.select(1, 10, 1)">{3,3,3}</li>
-                <li class="dropdown-item" onclick="Module.select(1, 10, 2)">{3,3,4}</li>
-                <li class="dropdown-item" onclick="Module.select(1, 10, 3)">{3,4,3}</li>
-                <li class="dropdown-item" onclick="Module.select(1, 10, 4)">{3,3,5}a</li>
-                <li class="dropdown-item" onclick="Module.select(1, 10, 5)">{3,3,5}b</li>
-                <li class="dropdown-item" onclick="Module.select(1, 10, 6)">{3,3,5}c</li>
-                <li class="dropdown-item" onclick="Module.select(1, 10, 7)">{3,3,5}d</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">222-family<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 11, 0)">2-2-2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 11, 1)"> 1</li>
-                <li class="dropdown-item" onclick="Module.select(1, 11, 2)"> 2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 11, 3)"> 3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 11, 4)"> 4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 11, 5)"> 1,2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 11, 6)"> 1,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 11, 7)"> 1,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 11, 8)"> 2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 11, 9)"> 2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 11, 10)"> 3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 11, 11)">1,2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 11, 12)">1,2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 11, 13)">1,3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 11, 14)">2,3,4</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">227-family<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 12, 0)">2-2-7</li>
-                <li class="dropdown-item" onclick="Module.select(1, 12, 1)"> 1</li>
-                <li class="dropdown-item" onclick="Module.select(1, 12, 2)"> 2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 12, 3)"> 3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 12, 4)"> 4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 12, 5)"> 1,2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 12, 6)"> 1,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 12, 7)"> 1,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 12, 8)"> 2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 12, 9)"> 2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 12, 10)"> 3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 12, 11)">1,2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 12, 12)">1,2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 12, 13)">1,3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 12, 14)">2,3,4</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">233-family<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 13, 0)">2-3-3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 13, 1)"> 1</li>
-                <li class="dropdown-item" onclick="Module.select(1, 13, 2)"> 2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 13, 3)"> 3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 13, 4)"> 4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 13, 5)"> 1,2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 13, 6)"> 1,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 13, 7)"> 1,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 13, 8)"> 2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 13, 9)"> 2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 13, 10)"> 3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 13, 11)">1,2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 13, 12)">1,2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 13, 13)">1,3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 13, 14)">2,3,4</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">234-family<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 14, 0)">2-3-4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 14, 1)"> 1</li>
-                <li class="dropdown-item" onclick="Module.select(1, 14, 2)"> 2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 14, 3)"> 3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 14, 4)"> 4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 14, 5)"> 1,2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 14, 6)"> 1,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 14, 7)"> 1,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 14, 8)"> 2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 14, 9)"> 2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 14, 10)"> 3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 14, 11)">1,2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 14, 12)">1,2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 14, 13)">1,3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 14, 14)">2,3,4</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">235-family<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 15, 0)">2-3-5</li>
-                <li class="dropdown-item" onclick="Module.select(1, 15, 1)"> 1</li>
-                <li class="dropdown-item" onclick="Module.select(1, 15, 2)"> 2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 15, 3)"> 3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 15, 4)"> 4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 15, 5)"> 1,2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 15, 6)"> 1,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 15, 7)"> 1,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 15, 8)"> 2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 15, 9)"> 2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 15, 10)"> 3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 15, 11)">1,2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 15, 12)">1,2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 15, 13)">1,3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 15, 14)">2,3,4</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item"> Y-family<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 16, 0)"> Y</li>
-                <li class="dropdown-item" onclick="Module.select(1, 16, 1)"> 1</li>
-                <li class="dropdown-item" onclick="Module.select(1, 16, 2)"> 2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 16, 3)"> 3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 16, 4)"> 4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 16, 5)"> 1,2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 16, 6)"> 1,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 16, 7)"> 1,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 16, 8)"> 2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 16, 9)"> 2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 16, 10)"> 3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 16, 11)">1,2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 16, 12)">1,2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 16, 13)">1,3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 16, 14)">2,3,4</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">333-family<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 17, 0)">3-3-3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 17, 1)"> 1</li>
-                <li class="dropdown-item" onclick="Module.select(1, 17, 2)"> 2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 17, 3)"> 3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 17, 4)"> 4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 17, 5)"> 1,2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 17, 6)"> 1,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 17, 7)"> 1,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 17, 8)"> 2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 17, 9)"> 2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 17, 10)"> 3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 17, 11)">1,2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 17, 12)">1,2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 17, 13)">1,3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 17, 14)">2,3,4</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">334-family<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 18, 0)">3-3-4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 18, 1)"> 1</li>
-                <li class="dropdown-item" onclick="Module.select(1, 18, 2)"> 2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 18, 3)"> 3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 18, 4)"> 4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 18, 5)"> 1,2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 18, 6)"> 1,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 18, 7)"> 1,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 18, 8)"> 2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 18, 9)"> 2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 18, 10)"> 3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 18, 11)">1,2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 18, 12)">1,2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 18, 13)">1,3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 18, 14)">2,3,4</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">343-family<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 19, 0)">3-4-3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 19, 1)"> 1</li>
-                <li class="dropdown-item" onclick="Module.select(1, 19, 2)"> 2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 19, 3)"> 3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 19, 4)"> 4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 19, 5)"> 1,2</li>
-                <li class="dropdown-item" onclick="Module.select(1, 19, 6)"> 1,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 19, 7)"> 1,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 19, 8)"> 2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 19, 9)"> 2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 19, 10)"> 3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 19, 11)">1,2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 19, 12)">1,2,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 19, 13)">1,3,4</li>
-                <li class="dropdown-item" onclick="Module.select(1, 19, 14)">2,3,4</li>
-              </ul>
-            </li>
-            <li>
-              <a class="dropdown-item">335-family<span class="float-end ms-2">»</span></a>
-              <ul class="submenu dropdown-menu">
-                <li class="dropdown-item" onclick="Module.select(1, 20, 0)">3-3-5</li>
-                <li class="dropdown-item" onclick="Module.select(1, 20, 1)">
-                  1
-                  <span class="float-end badge bg-light text-muted ms-3">Shift + F12</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 20, 2)">
-                  2
-                  <span class="float-end badge bg-light text-muted ms-3">Shift + F11</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 20, 3)">
-                  3
-                  <span class="float-end badge bg-light text-muted ms-3">Shift + F10</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 20, 4)">
-                  4
-                  <span class="float-end badge bg-light text-muted ms-3">Shift + F9</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 20, 5)">
-                  1,2
-                  <span class="float-end badge bg-light text-muted ms-3">Shift + F8</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 20, 6)">
-                  1,3
-                  <span class="float-end badge bg-light text-muted ms-3">Shift + F7</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 20, 7)">
-                  1,4
-                  <span class="float-end badge bg-light text-muted ms-3">Shift + F6</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 20, 8)">
-                  2,3
-                  <span class="float-end badge bg-light text-muted ms-3">Shift + F5</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 20, 9)">
-                  2,4
-                  <span class="float-end badge bg-light text-muted ms-3">Shift + F4</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 20, 10)">
-                  3,4
-                  <span class="float-end badge bg-light text-muted ms-3">Shift + F3</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 20, 11)">1,2,3</li>
-                <li class="dropdown-item" onclick="Module.select(1, 20, 12)">
-                  1,2,4
-                  <span class="float-end badge bg-light text-muted ms-3">Shift + F2</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 20, 13)">
-                  1,3,4
-                  <span class="float-end badge bg-light text-muted ms-3">Shift + F1</span>
-                </li>
-                <li class="dropdown-item" onclick="Module.select(1, 20, 14)">2,3,4</li>
-              </ul>
-            </li>
-          </ul>
-        </li>
-        <li>
-          <hr class="dropdown-divider">
-        </li>
-        <li>
-          <a class="dropdown-item">View<span class="float-end ms-2">&raquo;</span></a>
-          <ul class="submenu dropdown-menu">
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="toggle between mono and stereo"
-                onclick="Module.select(2, 0, -1)">
-              stereo/mono
-              <span class="float-end badge bg-light text-muted ms-3">1/2</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="see the model farther away"
-                onclick="Module.select(2, 1, -1)">
-              zoom out
-              <span class="float-end badge bg-light text-muted ms-3">&darr;</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="see the model closer up"
-                onclick="Module.select(2, 2, -1)">
-              zoom in
-              <span class="float-end badge bg-light text-muted ms-3">&uarr;</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="move the camera to the left"
-                onclick="Module.select(2, 3, -1)">
-              pan left
-              <span class="float-end badge bg-light text-muted ms-3">Shift + &larr;</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="move the camera to the right"
-                onclick="Module.select(2, 4, -1)">
-              pan right
-              <span class="float-end badge bg-light text-muted ms-3">Shift + &rarr;</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="move the camera up"
-                onclick="Module.select(2, 5, -1)">
-              pan up
-              <span class="float-end badge bg-light text-muted ms-3">Shift + &uarr;</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="move the camera down"
-                onclick="Module.select(2, 6, -1)">
-              pan down
-              <span class="float-end badge bg-light text-muted ms-3">Shift + &darr;</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="adjust the camera to the center of the model"
-                onclick="Module.select(2, 7, -1)">
-              pan center
-              <span class="float-end badge bg-light text-muted ms-3">P</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="enter fullscreen"
-                onclick="Module.select(2, 8, -1)">
-              fullscreen
-              <span class="float-end badge bg-light text-muted ms-3">F</span>
-            </li>
-          </ul>
-        </li>
-        <li>
-          <a class="dropdown-item">Move<span class="float-end ms-2">&raquo;</span></a>
-          <ul class="submenu dropdown-menu">
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="if you have a 1- or 2- button mouse, you can switch mouse channels"
-                onclick="Module.select(3, 0, -1)">
-              flip mouse
-              <span class="float-end badge bg-light text-muted ms-3">m</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="toggle drifting"
-                onclick="Module.select(3, 1, -1)">
-              drifting on/off
-              <span class="float-end badge bg-light text-muted ms-3">D</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="toggle the high/low drag to let the model float around freely"
-                onclick="Module.select(3, 2, -1)">
-              hi/lo drag
-              <span class="float-end badge bg-light text-muted ms-3">SPACE</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="make the model spring to the center"
-                onclick="Module.select(3, 3, -1)">
-              springy
-              <span class="float-end badge bg-light text-muted ms-3">c</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="invert the spring"
-                onclick="Module.select(3, 4, -1)">
-              flip spring
-              <span class="float-end badge bg-light text-muted ms-3">i</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="set the springs center"
-                onclick="Module.select(3, 5, -1)">
-              tare spring
-              <span class="float-end badge bg-light text-muted ms-3">C</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="slow down movement"
-                onclick="Module.select(3, 6, -1)">
-              slower
-              <span class="float-end badge bg-light text-muted ms-3">s</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="speed up movement"
-                onclick="Module.select(3, 7, -1)">
-              faster
-              <span class="float-end badge bg-light text-muted ms-3">S</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="reset motion"
-                onclick="Module.select(3, 8, -1)">
-              reset
-              <span class="float-end badge bg-light text-muted ms-3">x</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="toggle pause"
-                onclick="Module.select(3, 9, -1)">
-              pause
-              <span class="float-end badge bg-light text-muted ms-3">p</span>
-            </li>
-          </ul>
-        </li>
-        <li>
-          <a class="dropdown-item">Fly<span class="float-end ms-2">&raquo;</span></a>
-          <ul class="submenu dropdown-menu">
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="fly through a model"
-                onclick="Module.select(4, 0, -1)">
-              toggle flying
-              <span class="float-end badge bg-light text-muted ms-3">y</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="accelerate forward"
-                onclick="Module.select(4, 1, -1)">
-              forward
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="accelerate backward"
-                onclick="Module.select(4, 2, -1)">
-              backward
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="leave a trail line"
-                onclick="Module.select(4, 3, -1)">
-              trail line
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="leave a trail ribbon"
-                onclick="Module.select(4, 4, -1)">
-              trail ribbon
-              <span class="float-end badge bg-light text-muted ms-3">t</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="leave a trail tube"
-                onclick="Module.select(4, 5, -1)">
-              trail tube
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="break a trail or start a new trail"
-                onclick="Module.select(4, 6, -1)">
-              break trail
-              <span class="float-end badge bg-light text-muted ms-3">T</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="pause trail"
-                onclick="Module.select(4, 7, -1)">
-              pause trail
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="toggle between hiding and displaying the model"
-                onclick="Module.select(4, 8, -1)">
-              hide model
-            </li>
-          </ul>
-        </li>
-        <li>
-          <a class="dropdown-item">Style<span class="float-end ms-2">&raquo;</span></a>
-          <ul class="submenu dropdown-menu">
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="toggle faces"
-                onclick="Module.select(5, 0, -1)">
-              faces
-              <span class="float-end badge bg-light text-muted ms-3">f</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="toggle edges"
-                onclick="Module.select(5, 1, -1)">
-              edges
-              <span class="float-end badge bg-light text-muted ms-3">e</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="toggle vertices"
-                onclick="Module.select(5, 2, -1)">
-              vertices
-              <span class="float-end badge bg-light text-muted ms-3">v</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="very large models may look better in line-art style"
-                onclick="Module.select(5, 3, -1)">
-              line-art
-              <span class="float-end badge bg-light text-muted ms-3">h</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="toggle wireframe style"
-                onclick="Module.select(5, 4, -1)">
-              wireframe
-              <span class="float-end badge bg-light text-muted ms-3">w</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title=""
-                onclick="Module.select(5, 5, -1)">
-              thinner
-              <span class="float-end badge bg-light text-muted ms-3">-</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title=""
-                onclick="Module.select(5, 6, -1)">
-              fatter
-              <span class="float-end badge bg-light text-muted ms-3">+</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title=""
-                onclick="Module.select(5, 7, -1)">
-              fog
-              <span class="float-end badge bg-light text-muted ms-3">H</span>
-            </li>
-          </ul>
-        </li>
-        <li>
-          <a class="dropdown-item">Capture<span class="float-end ms-2">&raquo;</span></a>
-          <ul class="submenu dropdown-menu">
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="toggles between coarse/fine meshes"
-                onclick="Module.select(6, 0, -1)">
-              toggle quality
-              <span class="float-end badge bg-light text-muted ms-3">q</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="capture a screenshot in the original resolution"
-                onclick="captureImage()">
-              save 1x image
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="capture a screenshot with a scale factor of 2"
-                onclick="captureImage(2)">
-              save 2x image
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="capture a screenshot with a scale factor of 3"
-                onclick="captureImage(3)">
-              save 3x image
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="capture a screenshot with a scale factor of 4"
-                onclick="captureImage(4)">
-              save 4x image
-            </li>
-          </ul>
-        </li>
-
-        <li>
-          <a class="dropdown-item">Export<span class="float-end ms-2">&raquo;</span></a>
-          <ul class="submenu dropdown-menu">
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="exports geometry to the file jenn_export.stl"
-                onclick="Module.select(7, 0, -1)">
-              export to STL
-              <span class="float-end badge bg-light text-muted ms-3">g</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="toggles between coarse/fine meshes"
-                onclick="Module.select(7, 1, -1)">
-              toggle quality
-              <span class="float-end badge bg-light text-muted ms-3">q</span>
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="increase min edge/vertex thickness for exported model"
-                onclick="Module.select(7, 2, -1)">
-              + min thickness
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="decrease min edge/vertex thickness for exported model"
-                onclick="Module.select(7, 3, -1)">
-              - min thickness
-            </li>
-            <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
-                title="exports graph to simple text file"
-                onclick="Module.select(7, 4, -1)">
-              export graph
-              <span class="float-end badge bg-light text-muted ms-3">G</span>
-            </li>
-          </ul>
-        </li>
-        <li>
-          <hr class="dropdown-divider">
-        </li>
-        <li>
-          <div class="text-muted text-wrap px-3">
-            <div class="py-1">
-              <b>Rotate</b> <br> Drag with a 3-btn mouse (or ctrl-drag &amp; alt-drag)
-            </div>
-            <div class="py-1">
-              <b>Pan</b> <br> Shift-drag to pan<br>
-            </div>
-            <div class="py-1">
-              <b>In flying mode</b> <br> Right-drag controls speed <br> Left-drag steers direction
-            </div>
-          </div>
-        </li>
-      </ul>
-    </nav>
-  </aside>
-  <main class="col-xl-10">
-    <canvas id="canvas" class="container-fluid" tabindex=-1 oncontextmenu="event.preventDefault()"></canvas>
-  </main>
 </div>
 
-<footer id="footer" class="footer py-3 bg-light fixed-bottom text-center">
-  <div class="container">
-    <span class="text-muted">
-      Jenn3D was created by <a href="http://fritzo.org/" target="_blank">Fritz Obermeyer</a>,
-      and ported to the web by <a href="https://shawnzhong.com" target="_blank">Shawn Zhong</a>.
-    </span>
-  </div>
+<footer id="footer" class="footer mt-auto py-3 bg-light text-center">
+  <span class="text-muted">
+    Jenn3D was created by <a href="https://fritzo.org/" target="_blank">Fritz Obermeyer</a>,
+    and ported to the web by <a href="https://shawnzhong.com" target="_blank">Shawn Zhong</a>.
+  </span>
 </footer>
-
-
 
 <script>
   const triggerDownload = (url, filename) => {
@@ -845,19 +849,25 @@
   }
 
   // resize-related
-  const calculateCanvasSize = (aspectRatio = 5 / 4) => {
+  const calculateCanvasSize = (scaleFactor) => {
     if (document.fullscreen || document.mozFullScreen || document.webkitIsFullScreen) {
       return [screen.width, screen.height];
     }
-    const w = Module.canvas.getBoundingClientRect().width;
-    return [w, w / aspectRatio];
+
+    const dpi = window.devicePixelRatio;
+    const width = Module.canvas.clientWidth;
+    const size = Math.round(width * scaleFactor * dpi / 2);
+    return [size, size];
   }
 
   const resizeCanvas = (scaleFactor = 1) => {
-    const [w, h] = calculateCanvasSize();
-    const scaledWidth = w * scaleFactor;
-    const scaledHeight = h * scaleFactor;
-    Module.setCanvasSize(scaledWidth, scaledHeight);
+    const canvas = Module.canvas;
+    const [width, height] = calculateCanvasSize(scaleFactor);
+    if (canvas.width !== width || canvas.height !== height) {
+      canvas.width = width;
+      canvas.height = height;
+      Browser.updateResizeListeners();
+    }
   };
 
   let resizeTimer;

--- a/web/index.html
+++ b/web/index.html
@@ -53,7 +53,7 @@
 
 <body class="d-flex flex-column h-100">
 
-<div class="container-xl">
+<div class="container-xxl">
   <header class="d-flex flex-wrap align-items-center justify-content-center justify-content-md-between py-3 mb-4 border-bottom">
     <div class="d-flex align-items-center col-md-auto mb-2 mb-md-0">
       <h2><a href="https://jenn3d.org/" class="text-dark text-decoration-none" target="_blank">
@@ -553,12 +553,14 @@
           <li>
             <a class="dropdown-item">Move<span class="float-end ms-2">&raquo;</span></a>
             <ul class="submenu dropdown-menu">
+              <!--
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="if you have a 1- or 2- button mouse, you can switch mouse channels"
                   onclick="Module.select(3, 0, -1)">
                 flip mouse
                 <span class="float-end badge bg-light text-muted ms-3">m</span>
               </li>
+              -->
               <li class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
                   title="toggle drifting"
                   onclick="Module.select(3, 1, -1)">
@@ -752,7 +754,6 @@
               </li>
             </ul>
           </li>
-
           <li>
             <a class="dropdown-item">Export<span class="float-end ms-2">&raquo;</span></a>
             <ul class="submenu dropdown-menu">
@@ -789,19 +790,41 @@
           <li>
             <hr class="dropdown-divider">
           </li>
+
           <li>
-            <div class="text-muted text-wrap px-3">
-              <div class="py-1">
-                <b>Rotate</b> <br> Drag with a 3-btn mouse (or ctrl-drag &amp; alt-drag)
-              </div>
-              <div class="py-1">
-                <b>Pan</b> <br> Shift-drag to pan<br>
-              </div>
-              <div class="py-1">
-                <b>In flying mode</b> <br> Right-drag controls speed <br> Left-drag steers direction
-              </div>
+            <div class="text-wrap px-3 pb-1">
+              <b>Drag behavior</b>
+            </div>
+
+            <div class="dropdown-item text-decoration-underline" data-bs-toggle="tooltip" data-bs-placement="right"
+                 title="left-drag to rotate along the xz and yz direction, or steer direction in flying mode"
+                 onclick="changeDragBehavior(0, this)" data-radio="drag">
+              pitch &amp; yaw
+              <span class="float-end badge bg-light text-muted">Left</span>
+            </div>
+
+            <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                 title="right-drag or ctrl-drag to rotate along the xw and yw direction, or control speed in flying mode"
+                 onclick="changeDragBehavior(2, this)" data-radio="drag">
+              xw &amp; yw
+              <span class="float-end badge bg-light text-muted">Right/Ctrl</span>
+            </div>
+
+            <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                 title="middle-drag or alt-drag to rotate along the zw and xy direction"
+                 onclick="changeDragBehavior(4, this)" data-radio="drag">
+              zw &amp; roll
+              <span class="float-end badge bg-light text-muted">Mid/Alt</span>
+            </div>
+
+            <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                 title="shift-drag to pan the image"
+                 onclick="changeDragBehavior(1, this)" data-radio="drag">
+              move
+              <span class="float-end badge bg-light text-muted">Shift</span>
             </div>
           </li>
+
         </ul>
       </nav>
     </aside>
@@ -883,6 +906,23 @@
 
     Module.canvas.addEventListener("mousewheel", GLUT.onMouseWheel, true);
     Module.canvas.addEventListener("DOMMouseScroll", GLUT.onMouseWheel, true);
+  }
+
+  // control drag behavior
+  const dragElems = document.querySelectorAll('[data-radio="drag"]');
+  const changeDragBehavior = (key, el) => {
+    GLUT.saveModifiers = (event) => {
+      GLUT.modifiers = key;
+      if (event['shiftKey'])
+        GLUT.modifiers = 1; /* GLUT_ACTIVE_SHIFT */
+      if (event['ctrlKey'])
+        GLUT.modifiers = 2; /* GLUT_ACTIVE_CTRL */
+      if (event['altKey'])
+        GLUT.modifiers = 4; /* GLUT_ACTIVE_ALT */
+    }
+    const underline = "text-decoration-underline";
+    dragElems.forEach(e => e.classList.remove(underline));
+    el.classList.add(underline);
   }
 
   // wasm module

--- a/web/index.html
+++ b/web/index.html
@@ -797,12 +797,48 @@
               </li>
             </ul>
           </li>
+
+          <li>
+            <hr class="dropdown-divider">
+          </li>
+          <li>
+            <h6 class="dropdown-header fw-bold">Quick Actions</h6>
+
+            <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                 title="fly through a model"
+                 onclick="Module.select(4, 0, -1)">
+              fly
+              <span class="badge bg-light text-muted ms-3">y</span>
+            </div>
+
+            <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                 title="toggle the high/low drag to let the model float around freely"
+                 onclick="Module.select(3, 2, -1)">
+              drift
+              <span class="badge bg-light text-muted ms-3">SPACE</span>
+            </div>
+
+            <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                 title="make the model spring to the center"
+                 onclick="Module.select(3, 3, -1)">
+              springy
+              <span class="badge bg-light text-muted ms-3">c</span>
+            </div>
+
+            <div class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right"
+                 title="reset motion"
+                 onclick="Module.select(3, 8, -1)">
+              reset
+              <span class="badge bg-light text-muted ms-3">x</span>
+            </div>
+          </li>
+
           <li>
             <hr class="dropdown-divider">
           </li>
 
           <li>
-            <h6 class="dropdown-header fw-bold">Drag behavior</h6>
+            <h6 class="dropdown-header fw-bold">Drag Behavior</h6>
 
             <div class="dropdown-item active" data-bs-toggle="tooltip"
                  data-bs-placement="right"


### PR DESCRIPTION
See live site at https://shawnzhong.github.io/jenn3d/

- Mobile-friendly UI
  - Made the layout adjust to the screen size
  - Added drag behavior control so users can directly choose which drag mode they want
  - Implemented pinch-to-zoom on touch devices
  - Changed the aspect ratio of the canvas on smaller devices

- Reorganized the menu. Feel free to change the order or wording if you have a better one. 
  - Added section headers within the submenus
  - Added quick actions
  - Added `drawing->back`, `drawing->forward`, and `drawing->toggle_grid` to the menu. I found them from the keyboard shortcuts, but they were not on the menu for some reason. 

 - Implemented curved style. It improves the framerate a lot, especially on lower-end devices. I found the web app somewhat slow on integrated GPUs when I tested it on a friend's laptop. Surprisingly, it works quite well on my iPhone and another Android phone. 
 
- Changed the `Vertex` destructor using an iterative approach. I used to think that `delete next;` could be optimized by the compiler with tail recursion optimization, but it's not. For large models, the recursive approach exceeds the maximum call stack size on mobile devices because of stricter constraints. 


![2943A02B-8A12-46FD-967F-9734A1F6551A](https://user-images.githubusercontent.com/6421097/133849904-2fefffef-91f4-4aa1-80b1-2e31c0469d88.PNG)


@fritzo It might help if you hide white space changes when viewing the diff. 